### PR TITLE
Fix: Add commit after flush in annotation repository (fixes #7)

### DIFF
--- a/src/text2x/repositories/annotation.py
+++ b/src/text2x/repositories/annotation.py
@@ -65,6 +65,7 @@ class SchemaAnnotationRepository:
             )
             session.add(annotation)
             await session.flush()
+            await session.commit()
             await session.refresh(annotation)
             return annotation
 
@@ -208,6 +209,7 @@ class SchemaAnnotationRepository:
                 annotation.sensitive = sensitive
 
             await session.flush()
+            await session.commit()
             await session.refresh(annotation)
             return annotation
 


### PR DESCRIPTION
## Summary

Fixed a critical bug where annotations were not being saved to the database. The `SchemaAnnotationRepository` was using `flush()` without `commit()`, causing all changes to be rolled back when the session closed.

- Added `await session.commit()` after `await session.flush()` in `create()` method (line 68)
- Added `await session.commit()` after `await session.flush()` in `update()` method (line 212)

## Test plan

- [x] All existing tests pass (27 tests in test_annotation_flow.py and test_annotation_agent.py)
- [x] Verified changes are minimal and focused on the issue
- [x] Confirmed that `flush()` + `commit()` is the correct pattern for persisting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)