### PR TITLE
fix: Export UserRepository from repositories package (fixes #3)

### DIFF
--- a/src/text2x/repositories/__init__.py
+++ b/src/text2x/repositories/__init__.py
@@ -8,9 +8,11 @@ from .conversation import ConversationRepository, ConversationTurnRepository
 from .feedback import FeedbackRepository
 from .provider import ProviderRepository
 from .rag import RAGExampleRepository
+from .user import UserRepository
 from .workspace import WorkspaceRepository
 
 __all__ = [
+    "UserRepository",
     "ConnectionRepository",
     "ProviderRepository",
     "WorkspaceRepository",


### PR DESCRIPTION
## Summary
Exports `UserRepository` from the `text2x.repositories` package to create a consistent API with other repositories.

## Changes
- Added import: `from .user import UserRepository` to `src/text2x/repositories/__init__.py`
- Added `UserRepository` to the `__all__` list

## Fixes
- Closes #3
- Resolves inconsistent package API where UserRepository was not accessible via standard import pattern
- Aligns with pattern used for other repositories (AdminRepository, AnnotationRepository, etc.)

## Verification
After this change, the following import now works:
```python
from text2x.repositories import UserRepository  # Now works correctly
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)