### PR TITLE
🎨 Palette: Keyboard shortcut and a11y improvements for QueryInput

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,11 @@
+# Palette's Journal
+
+This journal records critical UX and accessibility learnings.
+
+## 2024-05-22 - [Initial Entry]
+**Learning:** Accessibility and intuitive interactions are foundational, not optional. Users rely on keyboard navigation and screen readers more than we think.
+**Action:** Always test with keyboard-only navigation and check ARIA labels.
+
+## 2024-05-22 - Keyboard Shortcuts Expectations
+**Learning:** Users expect platform-native shortcuts (Cmd+Enter on Mac, Ctrl+Enter on Windows) even if the UI text is ambiguous. Explicit handling is often required.
+**Action:** Implement explicit `e.metaKey || e.ctrlKey` checks for submission actions, don't rely on browser defaults for textareas.

--- a/frontend/e2e/pages/ChatPage.js
+++ b/frontend/e2e/pages/ChatPage.js
@@ -91,6 +91,16 @@ export class ChatPage {
   }
 
   /**
+   * Submit a query using keyboard shortcut (Ctrl+Enter)
+   *
+   * @param {string} query - The query text
+   */
+  async submitQueryWithKeyboard(query) {
+    await this.page.fill(this.queryInput, query);
+    await this.page.keyboard.press('Control+Enter');
+  }
+
+  /**
    * Wait for query to complete processing
    *
    * @param {number} timeout - Maximum time to wait (default 60s)

--- a/frontend/e2e/scenario-3-query-generation.spec.js
+++ b/frontend/e2e/scenario-3-query-generation.spec.js
@@ -26,6 +26,28 @@ test.describe('Scenario 3: Query Generation', () => {
     await expect(queryInput).toBeVisible();
   });
 
+  test('mock: should submit query using keyboard shortcut (Ctrl+Enter)', async ({ page }) => {
+    const chatPage = new ChatPage(page);
+
+    // Setup mock WebSocket responses BEFORE navigation
+    await setupMockWebSocket(page, MOCK_QUERY_RESPONSES.simpleQuery.events);
+
+    await chatPage.goto();
+    await chatPage.setupWebSocketInterception();
+
+    // Submit query using keyboard
+    await chatPage.submitQueryWithKeyboard(TEST_QUERIES.simple);
+
+    // Wait for completion
+    await page.waitForTimeout(2500); // Wait for all mock events
+
+    // Get WebSocket messages
+    const messages = await chatPage.getWebSocketMessages();
+
+    // Verify we received messages
+    expect(messages.length).toBeGreaterThan(0);
+  });
+
   test('mock: should submit query and receive result', async ({ page }) => {
     const chatPage = new ChatPage(page);
 

--- a/frontend/src/components/QueryInput.jsx
+++ b/frontend/src/components/QueryInput.jsx
@@ -41,8 +41,8 @@ const QueryInput = forwardRef(function QueryInput({ onSend, disabled, placeholde
   }
 
   const handleKeyDown = (e) => {
-    // Regular Enter (without Shift) to send
-    if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+    // Regular Enter (without Shift) or Mod+Enter to send
+    if (e.key === 'Enter' && (!e.shiftKey || e.metaKey || e.ctrlKey)) {
       e.preventDefault()
       handleSubmit(e)
       return
@@ -65,6 +65,7 @@ const QueryInput = forwardRef(function QueryInput({ onSend, disabled, placeholde
       <div className="flex-1">
         <textarea
           ref={textareaRef}
+          aria-label="Query input"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}


### PR DESCRIPTION
💡 What: Added keyboard shortcut (Ctrl/Cmd+Enter) for query submission and aria-label to the input field.
🎯 Why: Users expect standard keyboard shortcuts for sending messages in chat interfaces. Also improves accessibility for screen reader users.
📸 Before/After: (Functional change only)
♿ Accessibility: Added `aria-label="Query input"` to the textarea.

---
*PR created automatically by Jules for task [2315522142597267905](https://jules.google.com/task/2315522142597267905) started by @notacryptodad*