### PR TITLE
fix(ui): support Cmd/Ctrl+Enter in query input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2026-02-13 - Keyboard Shortcut Consistency
+**Learning:** Users rely on modifier keys like Ctrl/Cmd+Enter for form submission in textareas, even when helper text explicitly promises it. Implementations often miss checking for `metaKey` or `ctrlKey`.
+**Action:** Always verify keyboard event handlers account for platform-specific modifier keys when implementing shortcuts.

--- a/frontend/src/components/QueryInput.jsx
+++ b/frontend/src/components/QueryInput.jsx
@@ -41,8 +41,8 @@ const QueryInput = forwardRef(function QueryInput({ onSend, disabled, placeholde
   }
 
   const handleKeyDown = (e) => {
-    // Regular Enter (without Shift) to send
-    if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+    // Regular Enter (without Shift) or Mod+Enter to send
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey || !e.shiftKey)) {
       e.preventDefault()
       handleSubmit(e)
       return


### PR DESCRIPTION
- **frontend/src/components/QueryInput.jsx**: Updated `handleKeyDown` to trigger submission on `Cmd+Enter` or `Ctrl+Enter`, matching the helper text.
- **.Jules/palette.md**: Added journal entry about keyboard shortcut consistency.

Verified with `pnpm lint` and `pnpm build`. Ensure no lockfile changes are committed.

---
*PR created automatically by Jules for task [11377497823769531443](https://jules.google.com/task/11377497823769531443) started by @notacryptodad*