### PR TITLE
🎨 Palette: Add password visibility toggle to login page

### DIFF
--- a/frontend/e2e/ui-features.spec.js
+++ b/frontend/e2e/ui-features.spec.js
@@ -362,6 +362,26 @@ test.describe('Login Page', () => {
     // Should redirect to app
     await expect(page).toHaveURL(/\/app/, { timeout: 15000 });
   });
+
+  test('should toggle password visibility', async ({ page }) => {
+    await page.goto('http://localhost:5173/login');
+    await page.waitForLoadState('networkidle');
+
+    const passwordInput = page.locator('input[name="password"]');
+    // Look for button with aria-label containing "password" (Show password / Hide password)
+    const toggleButton = page.locator('button[aria-label*="password"]');
+
+    // Initial state should be password
+    await expect(passwordInput).toHaveAttribute('type', 'password');
+
+    // Click toggle to show password
+    await toggleButton.click();
+    await expect(passwordInput).toHaveAttribute('type', 'text');
+
+    // Click toggle to hide password
+    await toggleButton.click();
+    await expect(passwordInput).toHaveAttribute('type', 'password');
+  });
 });
 
 // Component file existence tests (don't need browser)

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link, useNavigate, useLocation } from 'react-router-dom'
-import { LogIn, Mail, Lock, AlertCircle, Loader2, Zap } from 'lucide-react'
+import { LogIn, Mail, Lock, AlertCircle, Loader2, Zap, Eye, EyeOff } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
 import * as ROUTES from '../constants/routes'
 
@@ -13,6 +13,7 @@ function Login() {
     email: '',
     password: '',
   })
+  const [showPassword, setShowPassword] = useState(false)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -132,15 +133,27 @@ function Login() {
                 <input
                   id="password"
                   name="password"
-                  type="password"
+                  type={showPassword ? 'text' : 'password'}
                   autoComplete="current-password"
                   required
                   value={formData.password}
                   onChange={handleChange}
-                  className="block w-full pl-10 pr-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                  className="block w-full pl-10 pr-10 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                   placeholder="Enter your password"
                   disabled={loading}
                 />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-500 focus:outline-none"
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                >
+                  {showPassword ? (
+                    <EyeOff className="h-5 w-5" aria-hidden="true" />
+                  ) : (
+                    <Eye className="h-5 w-5" aria-hidden="true" />
+                  )}
+                </button>
               </div>
             </div>
 
@@ -167,7 +180,7 @@ function Login() {
           {/* Register Link */}
           <div className="mt-6 text-center">
             <p className="text-sm text-gray-600 dark:text-gray-400">
-              Don't have an account?{' '}
+              Don&apos;t have an account?{' '}
               <Link
                 to={ROUTES.REGISTER}
                 className="font-medium text-primary-600 dark:text-primary-400 hover:text-primary-500 dark:hover:text-primary-300 transition-colors"


### PR DESCRIPTION
This PR adds a password visibility toggle to the login page, allowing users to show/hide their password. This improves UX by reducing login friction and errors.

Key changes:
- `frontend/src/pages/Login.jsx`: Added state, toggle button, and updated input type logic.
- `frontend/e2e/ui-features.spec.js`: Added a new test case to verify the toggle functionality.

Verified via manual inspection of screenshots and automated E2E test.

---
*PR created automatically by Jules for task [487274844208192588](https://jules.google.com/task/487274844208192588) started by @notacryptodad*