### PR TITLE
Improve QueryInput Accessibility and Keyboard Shortcuts

### DIFF
--- a/frontend/src/components/QueryInput.jsx
+++ b/frontend/src/components/QueryInput.jsx
@@ -41,8 +41,8 @@ const QueryInput = forwardRef(function QueryInput({ onSend, disabled, placeholde
   }
 
   const handleKeyDown = (e) => {
-    // Regular Enter (without Shift) to send
-    if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+    // Regular Enter (without Shift) or Mod+Enter to send
+    if (e.key === 'Enter' && !e.shiftKey && !e.altKey) {
       e.preventDefault()
       handleSubmit(e)
       return
@@ -69,6 +69,7 @@ const QueryInput = forwardRef(function QueryInput({ onSend, disabled, placeholde
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
+          aria-label="Enter your query"
           disabled={disabled || isLoading}
           rows={1}
           className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent outline-none resize-none text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed"


### PR DESCRIPTION
This change improves the usability and accessibility of the chat input component.
It adds a missing ARIA label to the textarea and explicitly handles `Ctrl+Enter` (Windows) and `Cmd+Enter` (Mac) keyboard shortcuts for submission, fulfilling the promise made in the helper text. It also ensures that `Shift+Enter` continues to insert a newline.
Verified by manual code review and successful build/lint checks. E2E tests were skipped due to environment limitations but logic is straightforward.

---
*PR created automatically by Jules for task [15212387151750129675](https://jules.google.com/task/15212387151750129675) started by @notacryptodad*