### PR TITLE
🎨 Palette: Improve accessibility of ChatMessage action buttons

### DIFF
--- a/frontend/src/components/ChatMessage.jsx
+++ b/frontend/src/components/ChatMessage.jsx
@@ -97,21 +97,23 @@ function ChatMessage({ message, conversationId }) {
                     <div className="flex items-center space-x-1">
                       <button
                         onClick={() => copyToClipboard(message.generatedQuery || message.content)}
-                        className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
+                        className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                         title="Copy query"
+                        aria-label={copied ? 'Query copied' : 'Copy query'}
                       >
                         {copied ? (
-                          <Check className="w-4 h-4 text-green-500" />
+                          <Check className="w-4 h-4 text-green-500" aria-hidden="true" />
                         ) : (
-                          <Copy className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+                          <Copy className="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true" />
                         )}
                       </button>
                       <button
                         onClick={() => downloadQuery(message.generatedQuery || message.content)}
-                        className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
+                        className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                         title="Download query"
+                        aria-label="Download query"
                       >
-                        <Download className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+                        <Download className="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true" />
                       </button>
                     </div>
                   </div>


### PR DESCRIPTION
Improved accessibility of Copy and Download buttons in ChatMessage component by adding ARIA labels, hiding decorative icons, and adding keyboard focus styles.

---
*PR created automatically by Jules for task [16885283395159227788](https://jules.google.com/task/16885283395159227788) started by @notacryptodad*