### PR TITLE
feat(frontend): implement Ctrl+Enter submit shortcut in QueryInput

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2026-02-18 - The "Ctrl+Enter" Lie
+**Learning:** Broken promises in UI (like claiming "Ctrl+Enter also works" without implementing it) frustrate users more than missing features.
+**Action:** When adding helper text about interactions, verify the implementation exists and handles platform variations (Ctrl vs Cmd).

--- a/frontend/src/components/QueryInput.jsx
+++ b/frontend/src/components/QueryInput.jsx
@@ -48,6 +48,13 @@ const QueryInput = forwardRef(function QueryInput({ onSend, disabled, placeholde
       return
     }
 
+    // Ctrl+Enter or Cmd+Enter to send
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      handleSubmit(e)
+      return
+    }
+
     // Up Arrow to recall last query when input is empty
     if (e.key === 'ArrowUp' && query.trim() === '' && lastQuery) {
       e.preventDefault()
@@ -88,7 +95,7 @@ const QueryInput = forwardRef(function QueryInput({ onSend, disabled, placeholde
       <button
         type="submit"
         disabled={disabled || isLoading || !query.trim()}
-        className="group relative flex-shrink-0 p-3 bg-primary-500 hover:bg-primary-600 disabled:bg-gray-300 dark:disabled:bg-gray-700 text-white rounded-lg transition-colors disabled:cursor-not-allowed shadow-sm hover:shadow-md"
+        className="group relative flex-shrink-0 p-3 bg-primary-500 hover:bg-primary-600 disabled:bg-gray-300 dark:disabled:bg-gray-700 text-white rounded-lg transition-colors disabled:cursor-not-allowed shadow-sm hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900"
         aria-label="Send query"
         title={`Send query (${modKey}+Enter)`}
       >


### PR DESCRIPTION
This PR addresses a UX inconsistency in the `QueryInput` component where the UI helper text advertised `Ctrl+Enter` support for submission, but the functionality was unimplemented.

Changes:
- Modified `frontend/src/components/QueryInput.jsx` to handle `Ctrl+Enter` and `Cmd+Enter` (Meta+Enter) key events to trigger form submission.
- Added `focus-visible` utility classes to the "Send" button to improve keyboard navigation accessibility.
- Added a journal entry in `.Jules/palette.md` reflecting on the importance of accurate UI text.

Verification:
- Validated code style with `pnpm lint`.
- Verified build success with `pnpm build`.
- Manually verified the fix using a custom Playwright script (`verification/verify_ux.py`) which successfully intercepted the API request triggered by `Ctrl+Enter`.


---
*PR created automatically by Jules for task [10492916187508047604](https://jules.google.com/task/10492916187508047604) started by @notacryptodad*