### PR TITLE
🎨 Palette: Enable Cmd+Enter submission for textareas

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-24 - Textarea Submission UX
+**Learning:** Users expect `Cmd+Enter` (Mac) or `Ctrl+Enter` (Windows) to submit forms when focused on a textarea, especially in chat or feedback interfaces.
+**Action:** Always add `onKeyDown` handlers to textareas that support this shortcut, checking for `(e.metaKey || e.ctrlKey) && e.key === 'Enter'`.

--- a/frontend/src/components/FeedbackButton.jsx
+++ b/frontend/src/components/FeedbackButton.jsx
@@ -83,6 +83,13 @@ function FeedbackButton({ conversationId, turnId, onFeedbackSubmit }) {
     setComments('')
   }
 
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      handleSubmitNegative(e)
+    }
+  }
+
   return (
     <>
       <div className="flex items-center space-x-2 mt-3 pt-3 border-t border-gray-200 dark:border-gray-600">
@@ -145,6 +152,7 @@ function FeedbackButton({ conversationId, turnId, onFeedbackSubmit }) {
                 <textarea
                   value={comments}
                   onChange={(e) => setComments(e.target.value)}
+                  onKeyDown={handleKeyDown}
                   placeholder="Please describe the issue with this query..."
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-700 dark:text-white"
                   rows="4"
@@ -159,6 +167,7 @@ function FeedbackButton({ conversationId, turnId, onFeedbackSubmit }) {
                 <textarea
                   value={correctedQuery}
                   onChange={(e) => setCorrectedQuery(e.target.value)}
+                  onKeyDown={handleKeyDown}
                   placeholder="If you know the correct query, paste it here..."
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-primary-500 focus:border-primary-500 dark:bg-gray-700 dark:text-white font-mono text-sm"
                   rows="6"

--- a/frontend/src/components/QueryInput.jsx
+++ b/frontend/src/components/QueryInput.jsx
@@ -48,6 +48,13 @@ const QueryInput = forwardRef(function QueryInput({ onSend, disabled, placeholde
       return
     }
 
+    // Cmd+Enter or Ctrl+Enter to send
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      handleSubmit(e)
+      return
+    }
+
     // Up Arrow to recall last query when input is empty
     if (e.key === 'ArrowUp' && query.trim() === '' && lastQuery) {
       e.preventDefault()


### PR DESCRIPTION
Implemented `Cmd+Enter` (Mac) and `Ctrl+Enter` (Windows) submission for textareas in `QueryInput` and `FeedbackButton`. This micro-UX improvement allows power users to submit forms without leaving the keyboard, matching the behavior described in the UI tooltip. Verified via code review and build check.

---
*PR created automatically by Jules for task [12805167314118285627](https://jules.google.com/task/12805167314118285627) started by @notacryptodad*