### PR TITLE
🎨 Palette: Improve query input accessibility and keyboard support

### DIFF
--- a/frontend/src/components/QueryInput.jsx
+++ b/frontend/src/components/QueryInput.jsx
@@ -41,8 +41,9 @@ const QueryInput = forwardRef(function QueryInput({ onSend, disabled, placeholde
   }
 
   const handleKeyDown = (e) => {
-    // Regular Enter (without Shift) to send
-    if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+    // Enter to send (supports Enter, Cmd+Enter, Ctrl+Enter)
+    // Only Shift+Enter inserts a new line
+    if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       handleSubmit(e)
       return
@@ -69,6 +70,7 @@ const QueryInput = forwardRef(function QueryInput({ onSend, disabled, placeholde
           onChange={(e) => setQuery(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
+          aria-label="Query input"
           disabled={disabled || isLoading}
           rows={1}
           className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent outline-none resize-none text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 disabled:opacity-50 disabled:cursor-not-allowed"


### PR DESCRIPTION
## 🎨 Palette: Improve query input accessibility and keyboard support

**💡 What:**
- Added `aria-label="Query input"` to the main query textarea.
- Updated `handleKeyDown` logic to correctly support `Cmd+Enter` (Mac) and `Ctrl+Enter` (Windows) for submission.

**🎯 Why:**
- Users relying on screen readers had no label for the main input field.
- The UI hint text claimed `Cmd+Enter` works, but the code explicitly prevented it. This change aligns behavior with user expectations and documentation.

**♿ Accessibility:**
- Added accessible name to the textarea via `aria-label`.
- Improved keyboard operability for power users.

---
*PR created automatically by Jules for task [16278431408953421320](https://jules.google.com/task/16278431408953421320) started by @notacryptodad*