### PR TITLE
🎨 Palette: Enhance Query Input Shortcuts

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-21 - Local vs Global Keyboard Shortcuts
+**Learning:** Global keyboard hooks often restrict modifier keys based on OS detection (e.g., only Cmd on Mac, only Ctrl on Windows), which can frustrate power users who expect both to work.
+**Action:** For input-specific shortcuts like 'Submit', implement local `onKeyDown` handlers that support both Ctrl+Enter and Meta+Enter universally, and use `e.stopPropagation()` to prevent conflicts with global listeners.

--- a/frontend/src/components/QueryInput.jsx
+++ b/frontend/src/components/QueryInput.jsx
@@ -41,9 +41,10 @@ const QueryInput = forwardRef(function QueryInput({ onSend, disabled, placeholde
   }
 
   const handleKeyDown = (e) => {
-    // Regular Enter (without Shift) to send
-    if (e.key === 'Enter' && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+    // Regular Enter (without Shift) OR Ctrl/Cmd+Enter to send
+    if (e.key === 'Enter' && (!e.shiftKey || e.metaKey || e.ctrlKey)) {
       e.preventDefault()
+      e.stopPropagation()
       handleSubmit(e)
       return
     }


### PR DESCRIPTION
💡 What: Implemented universal Ctrl+Enter and Meta+Enter (Cmd+Enter) keyboard shortcuts for submitting queries in the chat input.

🎯 Why: Users expect both shortcuts to work interchangeably or depending on their preference (Windows vs Mac), and the previous implementation relied on OS detection which excluded valid combinations (e.g. Meta+Enter on Linux). Also fixed a potential issue where helper text claimed support but the input didn't handle it directly.

📸 Before/After: No visual changes. Functional improvement only.

♿ Accessibility: Improved keyboard accessibility by supporting standard shortcuts for form submission.

Technical Details:
- Modified `handleKeyDown` in `frontend/src/components/QueryInput.jsx`.
- Added `e.stopPropagation()` to prevent the event from bubbling to the global window listener, avoiding double submission risks.
- Verified via E2E tests (mocked environment).

---
*PR created automatically by Jules for task [12269103900813709421](https://jules.google.com/task/12269103900813709421) started by @notacryptodad*