### PR TITLE
🎨 Palette: Improve AnnotationEditor Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Icon-Only Button Accessibility
+**Learning:** The application heavily uses `lucide-react` icons for action buttons (e.g., delete, close) without accompanying text or `aria-label` attributes, making them inaccessible to screen readers.
+**Action:** When encountering icon-only buttons, always ensure an `aria-label` is present describing the specific action and context (e.g., "Remove relationship to [Table Name]").

--- a/frontend/src/components/AnnotationEditor.jsx
+++ b/frontend/src/components/AnnotationEditor.jsx
@@ -202,6 +202,7 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
         <button
           onClick={onCancel}
           className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+          aria-label="Close annotation editor"
         >
           <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
         </button>
@@ -232,9 +233,10 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
               type="text"
               value={newBusinessTerm}
               onChange={(e) => setNewBusinessTerm(e.target.value)}
-              onKeyPress={(e) => e.key === 'Enter' && handleAddBusinessTerm()}
+              onKeyDown={(e) => e.key === 'Enter' && handleAddBusinessTerm()}
               placeholder="Add business term (e.g., Customer, Order)"
               className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+              aria-label="New business term"
             />
             <button
               onClick={handleAddBusinessTerm}
@@ -253,6 +255,7 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
                 <button
                   onClick={() => handleRemoveBusinessTerm(index)}
                   className="ml-2 hover:text-primary-900 dark:hover:text-primary-200"
+                  aria-label={`Remove business term ${term}`}
                 >
                   <X className="w-3 h-3" />
                 </button>
@@ -319,6 +322,7 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
                   <button
                     onClick={() => handleRemoveRelationship(index)}
                     className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
+                    aria-label={`Remove relationship to ${rel.target_table}`}
                   >
                     <X className="w-4 h-4 text-gray-500 dark:text-gray-400" />
                   </button>
@@ -334,6 +338,7 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
                 value={newRelationship.source_column}
                 onChange={(e) => setNewRelationship({ ...newRelationship, source_column: e.target.value })}
                 className="px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-xs focus:outline-none focus:ring-2 focus:ring-primary-500"
+                aria-label="Select source column"
               >
                 <option value="">Source column</option>
                 {tableSchema?.columns?.map(col => {
@@ -345,6 +350,7 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
                 value={newRelationship.target_table}
                 onChange={(e) => setNewRelationship({ ...newRelationship, target_table: e.target.value })}
                 className="px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-xs focus:outline-none focus:ring-2 focus:ring-primary-500"
+                aria-label="Select target table"
               >
                 <option value="">Target table</option>
                 {allTables.map(t => <option key={t} value={t}>{t}</option>)}
@@ -353,6 +359,7 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
                 value={newRelationship.type}
                 onChange={(e) => setNewRelationship({ ...newRelationship, type: e.target.value })}
                 className="px-2 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-xs focus:outline-none focus:ring-2 focus:ring-primary-500"
+                aria-label="Select relationship type"
               >
                 <option value="one_to_one">1:1</option>
                 <option value="one_to_many">1:N</option>
@@ -433,6 +440,7 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
                             onChange={(e) => handleColumnAnnotationChange(columnName, 'description', e.target.value)}
                             placeholder="Describe this column..."
                             className="w-full px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-xs focus:outline-none focus:ring-1 focus:ring-primary-500"
+                            aria-label={`Description for column ${columnName}`}
                           />
                         </td>
                         <td className="px-3 py-2">
@@ -442,6 +450,7 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
                             onChange={(e) => handleColumnAnnotationChange(columnName, 'sample_values', e.target.value)}
                             placeholder="e.g., active, pending, closed"
                             className="w-full px-2 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-xs focus:outline-none focus:ring-1 focus:ring-primary-500"
+                            aria-label={`Sample values for column ${columnName}`}
                           />
                         </td>
                       </tr>


### PR DESCRIPTION
💡 What: Added ARIA labels to icon-only buttons and inputs in the `AnnotationEditor` component. Replaced deprecated `onKeyPress` with `onKeyDown`.

🎯 Why: To improve accessibility for screen reader users and ensure keyboard navigation works correctly. The component previously relied on visual cues (icons) without text alternatives.

♿ Accessibility:
- Added `aria-label` to "Close annotation editor" button.
- Added `aria-label` to "Remove business term" and "Remove relationship" buttons.
- Added `aria-label` to "New business term" input.
- Added `aria-label` to relationship inputs (Source column, Target table, Relationship type).
- Added `aria-label` to column description and sample values inputs.
- Replaced `onKeyPress` with `onKeyDown` for better keyboard support.

---
*PR created automatically by Jules for task [3121356723008569165](https://jules.google.com/task/3121356723008569165) started by @notacryptodad*