### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons in AnnotationEditor

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-08 - ARIA labels on dynamic icon buttons
+**Learning:** In dynamic lists (like tags or relationships) in this app, generic 'Remove' ARIA labels aren't helpful enough for screen readers.
+**Action:** When adding ARIA labels to repeating elements, always include the dynamic target name (e.g., `Remove relationship with ${rel.target_table}`) for context.

--- a/frontend/src/components/AnnotationEditor.jsx
+++ b/frontend/src/components/AnnotationEditor.jsx
@@ -201,9 +201,10 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
         </h3>
         <button
           onClick={onCancel}
+          aria-label="Close annotation editor"
           className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
         >
-          <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+          <X aria-hidden="true" className="w-5 h-5 text-gray-500 dark:text-gray-400" />
         </button>
       </div>
 
@@ -252,9 +253,10 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
                 {term}
                 <button
                   onClick={() => handleRemoveBusinessTerm(index)}
+                  aria-label={`Remove business term ${term}`}
                   className="ml-2 hover:text-primary-900 dark:hover:text-primary-200"
                 >
-                  <X className="w-3 h-3" />
+                  <X aria-hidden="true" className="w-3 h-3" />
                 </button>
               </span>
             ))}
@@ -318,9 +320,10 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
                   </div>
                   <button
                     onClick={() => handleRemoveRelationship(index)}
+                    aria-label={`Remove relationship with ${rel.target_table}`}
                     className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
                   >
-                    <X className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+                    <X aria-hidden="true" className="w-4 h-4 text-gray-500 dark:text-gray-400" />
                   </button>
                 </div>
               ))}


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to the icon-only "Close" and "Remove" buttons, and `aria-hidden="true"` to the inner SVGs in `AnnotationEditor.jsx`.
🎯 Why: To ensure screen readers announce these icon-only buttons accurately, providing context (e.g., removing a specific business term or relationship target) rather than a generic or unannounced action.
♿ Accessibility: Improves accessibility for visually impaired users relying on screen readers to navigate dynamic tag and relationship lists.

---
*PR created automatically by Jules for task [5721290850365648469](https://jules.google.com/task/5721290850365648469) started by @notacryptodad*