### PR TITLE
🎨 Palette: Add ARIA labels to AnnotationEditor icon buttons

### DIFF
--- a/frontend/src/components/AnnotationEditor.jsx
+++ b/frontend/src/components/AnnotationEditor.jsx
@@ -202,8 +202,9 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
         <button
           onClick={onCancel}
           className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors"
+          aria-label="Close annotation editor"
         >
-          <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+          <X className="w-5 h-5 text-gray-500 dark:text-gray-400" aria-hidden="true" />
         </button>
       </div>
 
@@ -253,8 +254,9 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
                 <button
                   onClick={() => handleRemoveBusinessTerm(index)}
                   className="ml-2 hover:text-primary-900 dark:hover:text-primary-200"
+                  aria-label={`Remove business term ${term}`}
                 >
-                  <X className="w-3 h-3" />
+                  <X className="w-3 h-3" aria-hidden="true" />
                 </button>
               </span>
             ))}
@@ -319,8 +321,9 @@ function AnnotationEditor({ tableName, schema, annotation, onSave, onChange, onC
                   <button
                     onClick={() => handleRemoveRelationship(index)}
                     className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
+                    aria-label="Remove relationship"
                   >
-                    <X className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+                    <X className="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true" />
                   </button>
                 </div>
               ))}


### PR DESCRIPTION
💡 What: Added `aria-label` and `aria-hidden` attributes to icon-only buttons in `AnnotationEditor.jsx`.
🎯 Why: To improve screen reader accessibility by ensuring icon-only buttons have descriptive labels and their inner SVG icons are not redundantly announced.
📸 Before/After: Visuals are unchanged as this is purely an accessibility markup update.
♿ Accessibility:
- Added `aria-label="Close annotation editor"` and `aria-hidden="true"` to the close button.
- Added dynamic `aria-label` (e.g. `Remove business term {term}`) and `aria-hidden="true"` to the remove business term button.
- Added `aria-label="Remove relationship"` and `aria-hidden="true"` to the remove relationship button.

---
*PR created automatically by Jules for task [16077708242508782406](https://jules.google.com/task/16077708242508782406) started by @notacryptodad*