### PR TITLE
🎨 Palette: Improve Admin Sidebar Toggle Accessibility

### DIFF
--- a/frontend/src/components/AdminSidebar.jsx
+++ b/frontend/src/components/AdminSidebar.jsx
@@ -38,10 +38,16 @@ function AdminSidebar() {
         )}
         <button
           onClick={toggleCollapsed}
-          className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-500 dark:text-gray-400"
-          title={collapsed ? 'Expand' : 'Collapse'}
+          className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-500 dark:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+          title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          aria-expanded={!collapsed}
         >
-          {collapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
+          {collapsed ? (
+            <ChevronRight className="w-4 h-4" aria-hidden="true" />
+          ) : (
+            <ChevronLeft className="w-4 h-4" aria-hidden="true" />
+          )}
         </button>
       </div>
 


### PR DESCRIPTION
## 🎨 Palette: Improve Admin Sidebar Toggle Accessibility

**💡 What:** 
Added proper ARIA attributes (`aria-label`, `aria-expanded`, `aria-hidden`) and keyboard focus styles (`focus-visible`) to the expand/collapse toggle button in the `AdminSidebar` component.

**🎯 Why:** 
The toggle button was previously missing semantic attributes to indicate its state and purpose to screen readers. Relying only on the `title` attribute is insufficient for accessibility. Adding clear focus indicators ensures users navigating via keyboard can easily see when the button is focused.

**📸 Before/After:**
*Before:* Button only had a `title` attribute and no explicit focus ring.
*After:* Button has `aria-label`, correctly toggles `aria-expanded` based on state, hides decorative icons from screen readers with `aria-hidden="true"`, and displays a clear primary-colored ring when focused via keyboard.

**♿ Accessibility:** 
* Added `aria-label` for screen reader announcements.
* Added `aria-expanded` to communicate the open/closed state of the sidebar.
* Added `aria-hidden="true"` to decorative `lucide-react` icons.
* Added `focus-visible:ring-2 focus-visible:ring-primary-500` for clear keyboard focus indication.

---
*PR created automatically by Jules for task [1796586535930358624](https://jules.google.com/task/1796586535930358624) started by @notacryptodad*