### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons

### DIFF
--- a/frontend/src/components/QueryDiffView.jsx
+++ b/frontend/src/components/QueryDiffView.jsx
@@ -135,16 +135,16 @@ function QueryDiffView({ iterations, providerId }) {
       </div>
       {showDiff && diffPairs.length > 1 && (
         <div className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 rounded px-3 py-2">
-          <button onClick={() => setCurrentPairIndex(Math.max(0, currentPairIndex - 1))} disabled={currentPairIndex === 0} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
-            <ChevronLeft className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+          <button aria-label="Previous change" onClick={() => setCurrentPairIndex(Math.max(0, currentPairIndex - 1))} disabled={currentPairIndex === 0} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
+            <ChevronLeft className="w-4 h-4 text-gray-600 dark:text-gray-400" aria-hidden="true" />
           </button>
           <div className="text-xs text-gray-600 dark:text-gray-400">
             <span className="font-semibold">Iteration {currentPair.before.iteration || currentPairIndex + 1} to {currentPair.after.iteration || currentPairIndex + 2}</span>
             <span className="mx-2">|</span>
             <span>{currentPairIndex + 1} of {diffPairs.length} changes</span>
           </div>
-          <button onClick={() => setCurrentPairIndex(Math.min(diffPairs.length - 1, currentPairIndex + 1))} disabled={currentPairIndex === diffPairs.length - 1} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
-            <ChevronRight className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+          <button aria-label="Next change" onClick={() => setCurrentPairIndex(Math.min(diffPairs.length - 1, currentPairIndex + 1))} disabled={currentPairIndex === diffPairs.length - 1} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
+            <ChevronRight className="w-4 h-4 text-gray-600 dark:text-gray-400" aria-hidden="true" />
           </button>
         </div>
       )}

--- a/frontend/src/components/presentational/QueryBlock.jsx
+++ b/frontend/src/components/presentational/QueryBlock.jsx
@@ -26,19 +26,21 @@ function QueryBlock({
             onClick={onCopy}
             className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
             title="Copy query"
+            aria-label="Copy query"
           >
             {copied ? (
-              <Check className="w-4 h-4 text-green-500" />
+              <Check className="w-4 h-4 text-green-500" aria-hidden="true" />
             ) : (
-              <Copy className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+              <Copy className="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true" />
             )}
           </button>
           <button
             onClick={onDownload}
             className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded transition-colors"
             title="Download query"
+            aria-label="Download query"
           >
-            <Download className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+            <Download className="w-4 h-4 text-gray-500 dark:text-gray-400" aria-hidden="true" />
           </button>
         </div>
       </div>


### PR DESCRIPTION
## 💡 What
Added `aria-label` attributes to icon-only buttons in `QueryDiffView` (Previous/Next change buttons) and `QueryBlock` (Copy/Download buttons). Additionally, added `aria-hidden="true"` to the `lucide-react` SVG components within these buttons.

## 🎯 Why
Screen readers need text context to describe buttons that do not have visible text. This ensures visually impaired users navigating the application via keyboard or screen readers know what action the buttons will perform.

## 📸 Before/After
Visually, there are no changes, as this is purely a semantic HTML accessibility update.

## ♿ Accessibility
- Improves WCAG compliance for interactive elements without text labels.
- Prevents screen readers from reading out useless SVG properties and correctly reads out descriptive `aria-label`s instead.

---
*PR created automatically by Jules for task [7866957970464506056](https://jules.google.com/task/7866957970464506056) started by @notacryptodad*