### PR TITLE
🎨 Palette: [UX improvement] Add accessible labels to pagination buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-16 - Accessible Pagination Buttons
+**Learning:** Icon-only navigation buttons in custom tables (like ChevronLeft/ChevronRight for pagination) frequently lack `aria-label` attributes and screen reader-friendly text. In `ResultsTable`, they only had a visual chevron icon, making them incomprehensible for screen reader users.
+**Action:** Always check custom pagination controls and other small interaction buttons. Ensure icon-only buttons have a descriptive `aria-label` and that their inner SVG/icons have `aria-hidden="true"`.

--- a/frontend/src/components/results/ResultsTable.jsx
+++ b/frontend/src/components/results/ResultsTable.jsx
@@ -153,8 +153,9 @@ function ResultsTable({ data, columns }) {
               onClick={() => table.previousPage()}
               disabled={!table.getCanPreviousPage()}
               className="p-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              aria-label="Previous page"
             >
-              <ChevronLeft className="w-5 h-5 text-gray-600 dark:text-gray-400" />
+              <ChevronLeft className="w-5 h-5 text-gray-600 dark:text-gray-400" aria-hidden="true" />
             </button>
             <span className="px-3 py-1 text-gray-700 dark:text-gray-300">
               Page {table.getState().pagination.pageIndex + 1} of{' '}
@@ -164,8 +165,9 @@ function ResultsTable({ data, columns }) {
               onClick={() => table.nextPage()}
               disabled={!table.getCanNextPage()}
               className="p-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              aria-label="Next page"
             >
-              <ChevronRight className="w-5 h-5 text-gray-600 dark:text-gray-400" />
+              <ChevronRight className="w-5 h-5 text-gray-600 dark:text-gray-400" aria-hidden="true" />
             </button>
           </div>
         </div>


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to the "Previous Page" and "Next Page" pagination buttons in `ResultsTable.jsx`, and set `aria-hidden="true"` on their respective icons.

🎯 **Why:** These buttons are icon-only. Without an `aria-label`, screen reader users have no context for what these buttons do, making table pagination inaccessible. This small change ensures keyboard and screen reader users can navigate through data results effectively.

📸 **Before/After:** The change is purely structural for accessibility and does not alter the visual appearance of the buttons.

♿ **Accessibility:**
* Screen readers will now announce "Previous page" and "Next page" instead of ignoring the buttons or reading unhelpful icon descriptions.
* `aria-hidden="true"` on the icons themselves prevents redundant announcements.

---
*PR created automatically by Jules for task [18236283094983669075](https://jules.google.com/task/18236283094983669075) started by @notacryptodad*