### PR TITLE
🎨 Palette: Improve accessibility of ConversationHistory items

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-03-22 - Avoid Nested Interactive Elements in Lists
+
+**Learning:** When building clickable list items that also contain secondary actions (like delete buttons), using a wrapper `<div onClick={...}>` containing a `<button>` creates an accessibility anti-pattern (nested interactive elements). This breaks keyboard navigation and causes confusion for screen readers.
+
+**Action:** Refactor these structures to use a layout container (like a flex div) with sibling `<button>` elements—one primary button for selecting the item taking up the main space, and secondary buttons alongside it. Ensure each button has its own `aria-label` and `focus-visible` styles for clear, distinct keyboard navigation.

--- a/frontend/src/components/ConversationHistory.jsx
+++ b/frontend/src/components/ConversationHistory.jsx
@@ -35,10 +35,11 @@ function ConversationHistory({ conversations, currentId, onSelect, onNew, onDele
           </h2>
           <button
             onClick={onNew}
-            className="p-1.5 rounded-lg bg-primary-500 hover:bg-primary-600 text-white transition-colors"
+            className="p-1.5 rounded-lg bg-primary-500 hover:bg-primary-600 text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800"
             title="New conversation"
+            aria-label="New conversation"
           >
-            <Plus className="w-4 h-4" />
+            <Plus className="w-4 h-4" aria-hidden="true" />
           </button>
         </div>
       </div>
@@ -53,38 +54,37 @@ function ConversationHistory({ conversations, currentId, onSelect, onNew, onDele
             {conversations.map((conv) => (
               <div
                 key={conv.id}
-                className={`p-3 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors ${
+                className={`group relative flex hover:bg-gray-50 dark:hover:bg-gray-700/50 transition-colors ${
                   conv.id === currentId
                     ? 'bg-primary-50 dark:bg-primary-900/20 border-l-4 border-primary-500'
-                    : ''
+                    : 'border-l-4 border-transparent'
                 }`}
-                onClick={() => onSelect(conv.id)}
               >
-                <div className="flex items-start justify-between">
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
-                      {conv.provider || 'Conversation'}
-                    </p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 truncate">
-                      {getPreview(conv)}
-                    </p>
-                    <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-                      {formatDate(conv.timestamp)}
-                    </p>
-                  </div>
-                  {conv.id !== currentId && (
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        onDelete(conv.id)
-                      }}
-                      className="ml-2 p-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors"
-                      title="Delete conversation"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
-                  )}
-                </div>
+                <button
+                  className="flex-1 min-w-0 p-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-500 rounded-sm"
+                  onClick={() => onSelect(conv.id)}
+                  aria-label={`Select conversation: ${conv.provider || 'Conversation'}`}
+                >
+                  <p className="text-sm font-medium text-gray-900 dark:text-white truncate pr-8">
+                    {conv.provider || 'Conversation'}
+                  </p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 truncate pr-8">
+                    {getPreview(conv)}
+                  </p>
+                  <p className="text-xs text-gray-400 dark:text-gray-500 mt-1 pr-8">
+                    {formatDate(conv.timestamp)}
+                  </p>
+                </button>
+                {conv.id !== currentId && (
+                  <button
+                    onClick={() => onDelete(conv.id)}
+                    className="absolute right-3 top-3 p-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+                    title="Delete conversation"
+                    aria-label={`Delete conversation: ${conv.provider || 'Conversation'}`}
+                  >
+                    <Trash2 className="w-4 h-4" aria-hidden="true" />
+                  </button>
+                )}
               </div>
             ))}
           </div>


### PR DESCRIPTION
🎨 Palette: Improve accessibility of ConversationHistory items

💡 What: Refactored the conversation list items from nested interactive elements (`div` with `onClick` containing a delete `button`) to sibling `button` elements inside a flex container. Added `aria-label` and `focus-visible` styles to both the primary selection button and the icon-only "New" and "Delete" buttons.
🎯 Why: Nested interactive elements are an accessibility anti-pattern that breaks keyboard navigation and confuses screen readers. The added labels and focus states ensure the UI is fully keyboard accessible and semantic.
♿ Accessibility: Resolved nested interactive elements, added ARIA labels to icon buttons, hid decorative icons from screen readers, and implemented clear focus ring styles for all interactive elements.

---
*PR created automatically by Jules for task [8209044481365383973](https://jules.google.com/task/8209044481365383973) started by @notacryptodad*