### PR TITLE
🎨 Palette: Add accessibility states to Provider Select

### DIFF
--- a/frontend/src/components/ProviderSelect.jsx
+++ b/frontend/src/components/ProviderSelect.jsx
@@ -19,7 +19,8 @@ function ProviderSelect({ providers, selected, onChange, disabled = false }) {
           key={provider.id}
           onClick={() => !disabled && onChange(provider)}
           disabled={disabled}
-          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all ${
+          aria-pressed={selected?.id === provider.id}
+          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
             disabled
               ? 'opacity-50 cursor-not-allowed'
               : selected?.id === provider.id


### PR DESCRIPTION
💡 What: Added `aria-pressed` states and `focus-visible` styles to the Provider selection buttons.
🎯 Why: To clearly indicate selection state for screen readers and improve visual focus indicators for keyboard navigation users.
📸 Before/After: N/A - visual focus state and screen reader announcement changes.
♿ Accessibility: Improves WCAG compliance for focus visibility (2.4.7) and state announcement (4.1.2).

---
*PR created automatically by Jules for task [5038802274214599129](https://jules.google.com/task/5038802274214599129) started by @notacryptodad*