### PR TITLE
🎨 Palette: Add ARIA pressed and focus states to ProviderSelect

### DIFF
--- a/frontend/src/components/ProviderSelect.jsx
+++ b/frontend/src/components/ProviderSelect.jsx
@@ -19,7 +19,8 @@ function ProviderSelect({ providers, selected, onChange, disabled = false }) {
           key={provider.id}
           onClick={() => !disabled && onChange(provider)}
           disabled={disabled}
-          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all ${
+          aria-pressed={selected?.id === provider.id}
+          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
             disabled
               ? 'opacity-50 cursor-not-allowed'
               : selected?.id === provider.id


### PR DESCRIPTION
💡 **What**: Added `aria-pressed` attribute and `focus-visible` Tailwind classes to the provider button within the `ProviderSelect` component.
🎯 **Why**: Improves screen reader accessibility by declaring the toggle state of the button, and enhances keyboard navigation by providing a visible focus ring for users tabbing through options.
♿ **Accessibility**: Provides correct state context for AT users and visible focus indicators for keyboard-only users.

---
*PR created automatically by Jules for task [7741150824155046057](https://jules.google.com/task/7741150824155046057) started by @notacryptodad*