### PR TITLE
🎨 Palette: Add aria-pressed to ProviderSelect buttons

### DIFF
--- a/frontend/src/components/ProviderSelect.jsx
+++ b/frontend/src/components/ProviderSelect.jsx
@@ -19,6 +19,7 @@ function ProviderSelect({ providers, selected, onChange, disabled = false }) {
           key={provider.id}
           onClick={() => !disabled && onChange(provider)}
           disabled={disabled}
+          aria-pressed={selected?.id === provider.id}
           className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all ${
             disabled
               ? 'opacity-50 cursor-not-allowed'


### PR DESCRIPTION
💡 **What:** Added the `aria-pressed` attribute to the provider selection buttons in `ProviderSelect.jsx`.
🎯 **Why:** These buttons function as selectable cards/toggles. Without this attribute, screen reader users cannot tell which database provider is currently selected.
📸 **Before/After:** No visual change (this is a pure semantic HTML/a11y improvement).
♿ **Accessibility:** Screen readers will now explicitly announce the selected provider as "pressed" or "selected", making keyboard and screen reader navigation significantly more intuitive.

---
*PR created automatically by Jules for task [637268069747040098](https://jules.google.com/task/637268069747040098) started by @notacryptodad*