### PR TITLE
🎨 Palette: Improve ProviderSelect Accessibility

### DIFF
--- a/frontend/src/components/ProviderSelect.jsx
+++ b/frontend/src/components/ProviderSelect.jsx
@@ -19,7 +19,8 @@ function ProviderSelect({ providers, selected, onChange, disabled = false }) {
           key={provider.id}
           onClick={() => !disabled && onChange(provider)}
           disabled={disabled}
-          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all ${
+          aria-pressed={selected?.id === provider.id}
+          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-800 ${
             disabled
               ? 'opacity-50 cursor-not-allowed'
               : selected?.id === provider.id


### PR DESCRIPTION
🎨 Palette: Improve ProviderSelect Accessibility

**💡 What:** 
Added `aria-pressed` attributes to indicate active state for screen readers and introduced clear `focus-visible` ring utilities on the selection buttons inside the `ProviderSelect` component.

**🎯 Why:**
To make the provider selection list fully accessible for keyboard navigators and screen reader users without relying on mouse input or assumed visual queues.

**♿ Accessibility:**
- Keyboard navigation now clearly shows a primary-colored ring on the focused provider option.
- Screen readers will properly announce whether a provider is currently selected using the `aria-pressed` semantic attribute.

---
*PR created automatically by Jules for task [17552902301604246373](https://jules.google.com/task/17552902301604246373) started by @notacryptodad*