### PR TITLE
🎨 Palette: Improve ProviderSelect Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Improve Selectable Cards Accessibility
+**Learning:** For interactive elements functioning as selectable cards or toggle buttons (e.g., in lists like `ProviderSelect`), it is crucial to explicitly set the `aria-pressed` attribute based on their selection state to ensure proper screen reader accessibility. Additionally, clear keyboard focus indicators must be provided, such as by using `focus-visible` utility classes.
+**Action:** Use `aria-pressed={isSelected}` and Tailwind's `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500` classes when implementing any UI element that acts as a selectable card or toggle button rather than relying solely on visual styling like borders or backgrounds.

--- a/frontend/src/components/ProviderSelect.jsx
+++ b/frontend/src/components/ProviderSelect.jsx
@@ -19,7 +19,8 @@ function ProviderSelect({ providers, selected, onChange, disabled = false }) {
           key={provider.id}
           onClick={() => !disabled && onChange(provider)}
           disabled={disabled}
-          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all ${
+          aria-pressed={selected?.id === provider.id}
+          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
             disabled
               ? 'opacity-50 cursor-not-allowed'
               : selected?.id === provider.id


### PR DESCRIPTION
## 🎨 Palette: Improve Selectable Cards Accessibility

### 💡 What
Added `aria-pressed` attributes and `focus-visible` utility classes to the selectable cards in the `ProviderSelect` component.

### 🎯 Why
To ensure screen readers can properly identify the selection state of the provider cards, and to provide a clear visual indicator for keyboard navigation users, improving overall accessibility.

### 📸 Before/After
Before: The selectable cards lacked explicit screen reader state and clear keyboard focus rings.
After: The cards now correctly report their `aria-pressed` state and display a clear blue focus ring when navigated via keyboard.

### ♿ Accessibility
- Added `aria-pressed` to communicate toggle state to screen readers.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500` for clear keyboard focus indicators.

---
*PR created automatically by Jules for task [9591354884967075466](https://jules.google.com/task/9591354884967075466) started by @notacryptodad*