### PR TITLE
🎨 Palette: Add aria-pressed to ProviderSelect buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-06 - Accessible Selectable Cards
+**Learning:** When interactive elements function as selectable cards or toggle buttons (e.g., in a list of selectable providers where only one is active), using `aria-pressed="true"` or `aria-pressed="false"` explicitly communicates their selection state to screen readers better than visual cues alone.
+**Action:** Always add `aria-pressed={isSelected}` to `<button>` elements that act as mutually exclusive selection toggles or list options within a group.

--- a/frontend/src/components/ProviderSelect.jsx
+++ b/frontend/src/components/ProviderSelect.jsx
@@ -19,6 +19,7 @@ function ProviderSelect({ providers, selected, onChange, disabled = false }) {
           key={provider.id}
           onClick={() => !disabled && onChange(provider)}
           disabled={disabled}
+          aria-pressed={selected?.id === provider.id}
           className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all ${
             disabled
               ? 'opacity-50 cursor-not-allowed'


### PR DESCRIPTION
💡 **What:** Added `aria-pressed={selected?.id === provider.id}` to the provider selection buttons in `ProviderSelect.jsx`. Also created the `.Jules/palette.md` journal to log this finding.
🎯 **Why:** When interactive elements act as mutually exclusive selection cards, screen readers need an explicit attribute like `aria-pressed` to know which item is currently active, rather than relying solely on visual styling changes.
📸 **Before/After:** The visual appearance remains exactly the same, but the DOM now correctly reflects the pressed state for assistive technologies.
♿ **Accessibility:** Improves keyboard/screen reader navigation by explicitly communicating the selection state of the provider buttons.

---
*PR created automatically by Jules for task [6646008222915388065](https://jules.google.com/task/6646008222915388065) started by @notacryptodad*