### PR TITLE
🎨 Palette: Add `aria-pressed` to ProviderSelect buttons

### DIFF
--- a/frontend/src/components/ProviderSelect.jsx
+++ b/frontend/src/components/ProviderSelect.jsx
@@ -19,6 +19,7 @@ function ProviderSelect({ providers, selected, onChange, disabled = false }) {
           key={provider.id}
           onClick={() => !disabled && onChange(provider)}
           disabled={disabled}
+          aria-pressed={selected?.id === provider.id}
           className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all ${
             disabled
               ? 'opacity-50 cursor-not-allowed'


### PR DESCRIPTION
Added `aria-pressed` attribute to the `<button>` elements in `ProviderSelect.jsx` to improve screen reader accessibility and convey selection state.

---
*PR created automatically by Jules for task [17715527363034426864](https://jules.google.com/task/17715527363034426864) started by @notacryptodad*