### PR TITLE
🎨 Palette: Improve ProviderSelect keyboard navigation & accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-09 - Provider Select Accessibility
+**Learning:** The `<button>` elements used for selectable cards (like in `ProviderSelect`) should use `aria-pressed` to correctly announce their selected state to screen readers. They also lacked clear visual focus states for keyboard navigation.
+**Action:** When using buttons as toggleable items or selectable cards, always ensure `aria-pressed` reflects the current selection state, and apply `focus-visible` ring utility classes (e.g. `focus-visible:ring-primary-500`) to improve keyboard navigation accessibility.

--- a/frontend/src/components/ProviderSelect.jsx
+++ b/frontend/src/components/ProviderSelect.jsx
@@ -19,7 +19,8 @@ function ProviderSelect({ providers, selected, onChange, disabled = false }) {
           key={provider.id}
           onClick={() => !disabled && onChange(provider)}
           disabled={disabled}
-          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all ${
+          aria-pressed={selected?.id === provider.id}
+          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
             disabled
               ? 'opacity-50 cursor-not-allowed'
               : selected?.id === provider.id


### PR DESCRIPTION
💡 **What**: Added `aria-pressed` attributes to indicate selection state and `focus-visible` Tailwind classes for clearer keyboard navigation on the Provider Select buttons.

🎯 **Why**: Provider Selection buttons functioned as selectable cards but lacked screen reader context for their selected state and were hard to distinguish when navigating via keyboard (tabbing). This provides a tiny but vital accessibility win for screen-reader and power users.

♿ **Accessibility**: 
- Added `aria-pressed` to ensure screen-readers announce state (selected vs unselected).
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500` classes to clearly highlight the button when focused using keyboard without showing focus ring on mouse click.

---
*PR created automatically by Jules for task [3687243580643023655](https://jules.google.com/task/3687243580643023655) started by @notacryptodad*