### PR TITLE
🎨 Palette: Add ARIA labels to Query History sidebar buttons

### DIFF
--- a/frontend/src/components/QueryHistorySidebar.jsx
+++ b/frontend/src/components/QueryHistorySidebar.jsx
@@ -151,6 +151,7 @@ function QueryHistorySidebar({ isOpen, onClose, onRunQuery, providers = [], curr
           <button
             onClick={onClose}
             className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+            aria-label="Close query history"
           >
             <X className="w-5 h-5 text-gray-500" />
           </button>
@@ -224,12 +225,14 @@ function QueryHistorySidebar({ isOpen, onClose, onRunQuery, providers = [], curr
                         onClick={(e) => handleDelete(query.id, e)}
                         className="p-1 hover:bg-red-100 dark:hover:bg-red-900/30 rounded text-red-500"
                         title="Delete"
+                        aria-label="Delete query"
                       >
                         <Trash2 className="w-4 h-4" />
                       </button>
                       <button
                         className="p-1 hover:bg-indigo-100 dark:hover:bg-indigo-900/30 rounded text-indigo-500"
                         title="Run query"
+                        aria-label="Run query"
                       >
                         <Play className="w-4 h-4" />
                       </button>


### PR DESCRIPTION
💡 What: Added missing `aria-label` attributes to the "Close", "Delete", and "Run" icon buttons in the `QueryHistorySidebar` component.
🎯 Why: To improve accessibility for users relying on screen readers. Icon-only buttons without `aria-label`s are opaque to screen readers.
📸 Before/After: Visuals remain unchanged, but structural accessibility is improved.
♿ Accessibility: Improved keyboard navigation and screen reader support for the Query History sidebar.

---
*PR created automatically by Jules for task [17088304471620531129](https://jules.google.com/task/17088304471620531129) started by @notacryptodad*