### PR TITLE
🎨 Palette: Use semantic buttons for interactive list items in WelcomeScreen

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-14 - Semantic interactive elements in lists
+**Learning:** When displaying clickable lists (like example queries), using generic tags like `<div onClick={...}>` instead of semantic `<button>` elements breaks keyboard navigation and screen reader support. This app often uses clickable divs for lists because they naturally block out content, but this is an accessibility anti-pattern.
+**Action:** Always use `<button type="button">` with the `w-full` class (to emulate block behavior if needed) for clickable list items. Ensure they have appropriate `focus-visible` styles (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500`) to support keyboard navigation.

--- a/frontend/src/components/WelcomeScreen.jsx
+++ b/frontend/src/components/WelcomeScreen.jsx
@@ -16,8 +16,10 @@ function WelcomeScreen({ onGetStarted }) {
         {/* Collapse Toggle */}
         <button
           onClick={() => setIsCollapsed(!isCollapsed)}
-          className="mb-4 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          className="mb-4 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 transition-colors"
           title={isCollapsed ? 'Expand' : 'Collapse'}
+          aria-expanded={!isCollapsed}
+          aria-label={isCollapsed ? 'Expand welcome screen' : 'Collapse welcome screen'}
         >
           {isCollapsed ? <ChevronDown className="w-5 h-5 text-gray-500" /> : <ChevronUp className="w-5 h-5 text-gray-500" />}
         </button>
@@ -87,14 +89,15 @@ function WelcomeScreen({ onGetStarted }) {
               </p>
               <div className="space-y-2">
                 {exampleQueries.map((query, idx) => (
-                  <div
+                  <button
                     key={idx}
-                    className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:border-primary-300 dark:hover:border-primary-700 transition-colors cursor-pointer"
+                    type="button"
+                    className="w-full bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-4 py-2 text-left text-sm text-gray-700 dark:text-gray-300 hover:border-primary-300 dark:hover:border-primary-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 transition-colors cursor-pointer"
                     onClick={() => onGetStarted && onGetStarted(query)}
                   >
                     <span className="text-primary-500 mr-2">→</span>
                     {query}
-                  </div>
+                  </button>
                 ))}
               </div>
             </div>
@@ -102,7 +105,7 @@ function WelcomeScreen({ onGetStarted }) {
             {/* CTA Button */}
             <button
               onClick={() => onGetStarted && onGetStarted()}
-              className="inline-flex items-center space-x-2 px-6 py-3 bg-primary-500 hover:bg-primary-600 text-white font-semibold rounded-lg shadow-lg hover:shadow-xl transition-all"
+              className="inline-flex items-center space-x-2 px-6 py-3 bg-primary-500 hover:bg-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 text-white font-semibold rounded-lg shadow-lg hover:shadow-xl transition-all"
             >
               <span>Get Started</span>
               <ArrowRight className="w-5 h-5" />


### PR DESCRIPTION
🎨 Palette: Use semantic buttons for interactive list items in WelcomeScreen

💡 What: Changed the example queries list items from `<div onClick={...}>` to `<button type="button">`. Added `aria-expanded` and `aria-label` to the collapse toggle. Added focus-visible styles to all interactive elements in `WelcomeScreen.jsx`. Added an entry to `.Jules/palette.md` noting the pattern.
🎯 Why: Using divs for interactive elements breaks keyboard navigation and screen reader support. Using semantic buttons ensures that these elements are accessible. Adding focus-visible classes ensures keyboard users can see what element has focus.
♿ Accessibility: Improved keyboard navigation support for example queries and buttons, added proper ARIA attributes for screen readers.

---
*PR created automatically by Jules for task [4957028141660350034](https://jules.google.com/task/4957028141660350034) started by @notacryptodad*