### PR TITLE
🎨 Palette: Add accessibility attributes and focus styles to ProviderSelect

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-20 - Selectable Cards Accessibility
+**Learning:** List items functioning as selectable cards/toggles require explicit state indication and keyboard focus visibility to be accessible. A generic 'button' role is not enough.
+**Action:** Always add `aria-pressed` based on selection state and use `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500` for clear keyboard navigation focus states on selectable items.

--- a/frontend/src/components/ProviderSelect.jsx
+++ b/frontend/src/components/ProviderSelect.jsx
@@ -19,7 +19,8 @@ function ProviderSelect({ providers, selected, onChange, disabled = false }) {
           key={provider.id}
           onClick={() => !disabled && onChange(provider)}
           disabled={disabled}
-          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all ${
+          aria-pressed={selected?.id === provider.id}
+          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
             disabled
               ? 'opacity-50 cursor-not-allowed'
               : selected?.id === provider.id


### PR DESCRIPTION
- 💡 What: Added `aria-pressed` and `focus-visible` styles to the selectable provider buttons in `ProviderSelect.jsx`.
- 🎯 Why: To improve accessibility for screen readers (conveying selection state) and keyboard users (providing clear visual focus indication).
- ♿ Accessibility: Improved keyboard navigation focus visibility and proper screen reader role/state indicators for toggleable items.

---
*PR created automatically by Jules for task [4546884637346374393](https://jules.google.com/task/4546884637346374393) started by @notacryptodad*