### PR TITLE
🎨 Palette: Improve accessibility of ProviderSelect toggle cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-22 - Interactive Selection Cards Need aria-pressed
+**Learning:** When using `<button>` elements as selectable cards or list items (like in `ProviderSelect`), screen readers need to know which option is currently selected. Adding `aria-pressed` properly announces this state.
+**Action:** Always add `aria-pressed={isSelected}` to custom selectable buttons, along with `type="button"` and `focus-visible` utility classes for complete accessibility.

--- a/frontend/src/components/ProviderSelect.jsx
+++ b/frontend/src/components/ProviderSelect.jsx
@@ -17,9 +17,11 @@ function ProviderSelect({ providers, selected, onChange, disabled = false }) {
       {providers.map((provider) => (
         <button
           key={provider.id}
+          type="button"
+          aria-pressed={selected?.id === provider.id}
           onClick={() => !disabled && onChange(provider)}
           disabled={disabled}
-          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all ${
+          className={`w-full flex items-center justify-between p-3 rounded-lg border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
             disabled
               ? 'opacity-50 cursor-not-allowed'
               : selected?.id === provider.id


### PR DESCRIPTION
💡 What: Added `type="button"`, `aria-pressed`, and `focus-visible` outline styles to the selectable cards in `ProviderSelect.jsx`.
🎯 Why: Makes the selection cards semantically correct, announces the selected state to screen readers, and adds a clear visual indicator for keyboard navigation.
📸 Before/After: Verified visual focus ring and selected state with Playwright.
♿ Accessibility: Improves WCAG compliance for interactive selection lists.

---
*PR created automatically by Jules for task [9080320825651135515](https://jules.google.com/task/9080320825651135515) started by @notacryptodad*