### PR TITLE
🎨 Palette: Add aria-labels to icon-only buttons

### DIFF
--- a/frontend/src/components/ConversationHistory.jsx
+++ b/frontend/src/components/ConversationHistory.jsx
@@ -34,6 +34,7 @@ function ConversationHistory({ conversations, currentId, onSelect, onNew, onDele
             <span>History</span>
           </h2>
           <button
+            aria-label="New conversation"
             onClick={onNew}
             className="p-1.5 rounded-lg bg-primary-500 hover:bg-primary-600 text-white transition-colors"
             title="New conversation"
@@ -74,6 +75,7 @@ function ConversationHistory({ conversations, currentId, onSelect, onNew, onDele
                   </div>
                   {conv.id !== currentId && (
                     <button
+                      aria-label="Delete conversation"
                       onClick={(e) => {
                         e.stopPropagation()
                         onDelete(conv.id)

--- a/frontend/src/components/QueryDiffView.jsx
+++ b/frontend/src/components/QueryDiffView.jsx
@@ -135,7 +135,7 @@ function QueryDiffView({ iterations, providerId }) {
       </div>
       {showDiff && diffPairs.length > 1 && (
         <div className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 rounded px-3 py-2">
-          <button onClick={() => setCurrentPairIndex(Math.max(0, currentPairIndex - 1))} disabled={currentPairIndex === 0} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
+          <button aria-label="Previous diff" onClick={() => setCurrentPairIndex(Math.max(0, currentPairIndex - 1))} disabled={currentPairIndex === 0} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
             <ChevronLeft className="w-4 h-4 text-gray-600 dark:text-gray-400" />
           </button>
           <div className="text-xs text-gray-600 dark:text-gray-400">
@@ -143,7 +143,7 @@ function QueryDiffView({ iterations, providerId }) {
             <span className="mx-2">|</span>
             <span>{currentPairIndex + 1} of {diffPairs.length} changes</span>
           </div>
-          <button onClick={() => setCurrentPairIndex(Math.min(diffPairs.length - 1, currentPairIndex + 1))} disabled={currentPairIndex === diffPairs.length - 1} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
+          <button aria-label="Next diff" onClick={() => setCurrentPairIndex(Math.min(diffPairs.length - 1, currentPairIndex + 1))} disabled={currentPairIndex === diffPairs.length - 1} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
             <ChevronRight className="w-4 h-4 text-gray-600 dark:text-gray-400" />
           </button>
         </div>

--- a/frontend/src/components/QueryHistorySidebar.jsx
+++ b/frontend/src/components/QueryHistorySidebar.jsx
@@ -149,6 +149,7 @@ function QueryHistorySidebar({ isOpen, onClose, onRunQuery, providers = [], curr
             <h2 className="text-lg font-semibold text-gray-900 dark:text-white">Query History</h2>
           </div>
           <button
+            aria-label="Close query history"
             onClick={onClose}
             className="p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
           >
@@ -221,6 +222,7 @@ function QueryHistorySidebar({ isOpen, onClose, onRunQuery, providers = [], curr
                     </div>
                     <div className="flex items-center space-x-1 opacity-0 group-hover:opacity-100 transition-opacity">
                       <button
+                        aria-label="Delete query"
                         onClick={(e) => handleDelete(query.id, e)}
                         className="p-1 hover:bg-red-100 dark:hover:bg-red-900/30 rounded text-red-500"
                         title="Delete"
@@ -228,6 +230,7 @@ function QueryHistorySidebar({ isOpen, onClose, onRunQuery, providers = [], curr
                         <Trash2 className="w-4 h-4" />
                       </button>
                       <button
+                        aria-label="Run query"
                         className="p-1 hover:bg-indigo-100 dark:hover:bg-indigo-900/30 rounded text-indigo-500"
                         title="Run query"
                       >

--- a/frontend/src/components/TemplatesPicker.jsx
+++ b/frontend/src/components/TemplatesPicker.jsx
@@ -73,7 +73,7 @@ function TemplatesPicker({ providerType, onSelectTemplate, disabled }) {
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
               <input type="text" value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} placeholder="Search templates..."
                 className="w-full pl-9 pr-8 py-2 text-sm bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-2 focus:ring-primary-500 focus:border-transparent outline-none text-gray-900 dark:text-white placeholder-gray-400" />
-              {searchQuery && <button onClick={() => setSearchQuery('')} className="absolute right-2 top-1/2 -translate-y-1/2 p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"><X className="w-3 h-3 text-gray-400" /></button>}
+              {searchQuery && <button aria-label="Clear search" onClick={() => setSearchQuery('')} className="absolute right-2 top-1/2 -translate-y-1/2 p-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded"><X className="w-3 h-3 text-gray-400" /></button>}
             </div>
           </div>
 


### PR DESCRIPTION
🎨 **Palette: Added missing ARIA labels to icon-only buttons**

💡 **What**: Added `aria-label` attributes to icon-only buttons across multiple components (`ConversationHistory`, `QueryHistorySidebar`, `QueryDiffView`, and `TemplatesPicker`).
🎯 **Why**: Icon-only buttons without accessible names cannot be understood by screen readers, making the interface inaccessible for users relying on assistive technologies. 
♿ **Accessibility**: Improves keyboard navigation and screen reader support by ensuring clear descriptions of button actions (e.g., "New conversation", "Delete query", "Next diff").

---
*PR created automatically by Jules for task [13591309591419077364](https://jules.google.com/task/13591309591419077364) started by @notacryptodad*