### PR TITLE
🎨 Palette: Make query results table fully accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-26 - TanStack Table Interactive Header Accessibility
+**Learning:** By default, generic `<th>` elements used with TanStack Table sorting handlers are not accessible to keyboard users or screen readers. They require manual addition of `tabIndex`, `onKeyDown` handlers (specifically for Enter and Space), and dynamic `aria-sort` attributes to function identically to native interactive elements.
+**Action:** When implementing custom sorting in React Table, ensure interactive column headers include these three accessibility primitives and visual focus indicators (`focus-visible` utility classes) to support keyboard navigation.

--- a/frontend/src/components/results/ResultsTable.jsx
+++ b/frontend/src/components/results/ResultsTable.jsx
@@ -74,8 +74,22 @@ function ResultsTable({ data, columns }) {
                 {headerGroup.headers.map((header) => (
                   <th
                     key={header.id}
-                    className="px-4 py-3 text-left text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors select-none"
+                    className="px-4 py-3 text-left text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors select-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                     onClick={header.column.getToggleSortingHandler()}
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        header.column.getToggleSortingHandler()?.(e);
+                      }
+                    }}
+                    aria-sort={
+                      header.column.getIsSorted() === 'asc'
+                        ? 'ascending'
+                        : header.column.getIsSorted() === 'desc'
+                        ? 'descending'
+                        : 'none'
+                    }
                   >
                     <div className="flex items-center space-x-1">
                       <span>
@@ -138,7 +152,8 @@ function ResultsTable({ data, columns }) {
             onChange={(e) => {
               table.setPageSize(Number(e.target.value))
             }}
-            className="px-3 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-sm"
+            className="px-3 py-1 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+            aria-label="Items per page"
           >
             {[10, 20, 50, 100].map((pageSize) => (
               <option key={pageSize} value={pageSize}>
@@ -152,7 +167,8 @@ function ResultsTable({ data, columns }) {
             <button
               onClick={() => table.previousPage()}
               disabled={!table.getCanPreviousPage()}
-              className="p-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="p-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+              aria-label="Previous page"
             >
               <ChevronLeft className="w-5 h-5 text-gray-600 dark:text-gray-400" />
             </button>
@@ -163,7 +179,8 @@ function ResultsTable({ data, columns }) {
             <button
               onClick={() => table.nextPage()}
               disabled={!table.getCanNextPage()}
-              className="p-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              className="p-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+              aria-label="Next page"
             >
               <ChevronRight className="w-5 h-5 text-gray-600 dark:text-gray-400" />
             </button>


### PR DESCRIPTION
**💡 What**
Improved the accessibility of the `ResultsTable` component by making the sorting column headers and pagination controls fully navigable and readable by keyboard and screen readers.

**🎯 Why**
By default, generic HTML `<th>` elements do not receive keyboard focus or communicate interactive state to screen readers, even when `onClick` handlers are attached via TanStack Table. Users relying on keyboard navigation could not sort data or see which columns were sortable. Pagination icon-only buttons lacked descriptive labels. This change ensures compliance with accessibility best practices without altering the existing visual design.

**📸 Before/After**
- Headers are now focusable via `Tab`.
- Headers can be triggered to sort using `Enter` or `Space` keys.
- Focus outlines (`focus-visible:ring-primary-500`) are applied only when using keyboard navigation, maintaining a clean visual appearance for mouse users.
- Pagination buttons now correctly announce "Previous page", "Next page", and "Items per page".

**♿ Accessibility**
- Added `tabIndex={0}` to active table headers.
- Added `onKeyDown` handlers catching 'Enter' and ' ' (Space) events.
- Added dynamic `aria-sort` attributes ('ascending', 'descending', or 'none').
- Added `aria-label` attributes to pagination `<button>` and `<select>` elements.
- Applied `focus-visible` Tailwind classes uniformly to all interactive elements in the component.

Additionally, documented this recurring UX pattern in `.Jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [16735001780283742397](https://jules.google.com/task/16735001780283742397) started by @notacryptodad*