### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility and keyboard focus

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -12,12 +12,15 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         relative p-2 rounded-lg 
         bg-gray-100 dark:bg-gray-700 
         hover:bg-gray-200 dark:hover:bg-gray-600 
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500
         transition-colors duration-200
         overflow-hidden
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**What:**
- Added `role="switch"` and `aria-checked` to the `ThemeToggle` component to provide correct semantics.
- Changed the `aria-label` from an action ("Switch to dark mode") to a static noun ("Dark mode") so screen readers can correctly read the checked state.
- Added Tailwind focus-visible classes (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500`) to improve keyboard navigation visibility.

**Why:**
- Previously, the button lacked the proper switch semantics, making it unclear to screen reader users what state the toggle was in.
- Keyboard users lacked a clear visual indicator of focus when tabbing to the component.

**Before/After:**
- Before: Generic button lacking switch semantics, no focus ring.
- After: Semantic switch with correct state announcements and clear focus ring on keyboard navigation.

**Accessibility:**
- Corrects screen reader announcements for the toggle switch.
- Improves keyboard navigation by making the focus state highly visible.

---
*PR created automatically by Jules for task [14743094473340829839](https://jules.google.com/task/14743094473340829839) started by @notacryptodad*