### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 What: Added `role="switch"`, `aria-checked`, and a static `aria-label` ("Dark mode") to the ThemeToggle component.
🎯 Why: Previously, the theme toggle was a generic button whose `aria-label` changed based on the state ("Switch to light mode" / "Switch to dark mode"). By turning it into a semantic switch, screen readers provide a much more intuitive experience (e.g., announcing "Dark mode, switch, checked" when active).
📸 Before/After: Visuals remain unchanged; purely an accessibility improvement.
♿ Accessibility: Improves screen reader compatibility for interactive state-toggling elements by adhering to WAI-ARIA switch role guidelines.

---
*PR created automatically by Jules for task [16135481749528903942](https://jules.google.com/task/16135481749528903942) started by @notacryptodad*