### PR TITLE
🎨 Palette: Make theme toggle an accessible switch

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -14,10 +14,13 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         hover:bg-gray-200 dark:hover:bg-gray-600 
         transition-colors duration-200
         overflow-hidden
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 What: Updated the `ThemeToggle` component to use the `role="switch"` attribute alongside `aria-checked={darkMode}`. Also updated the `aria-label` to clearly identify the setting being modified, and explicitly added `focus-visible` styles to guarantee keyboard navigation clarity.
🎯 Why: A generic button wrapping two icons that simply flips its label ("Switch to light mode" / "Switch to dark mode") leaves screen readers without vital context on the underlying state. Giving it a switch role accurately conveys that this is a stateful toggle, letting screen-reader users hear exactly what its current state is. Focus rings further guide keyboard users directly to the element.
📸 Before/After: Before, just a button. After, a semantic, accessible switch with a distinct visible focus outline.
♿ Accessibility:
- Added `role="switch"`
- Added `aria-checked` to announce state automatically.
- Switched dynamic action-based `aria-label` to setting-based "Dark mode".
- Added `focus-visible:ring-2` to guarantee a clear visual ring on keyboard focus.

---
*PR created automatically by Jules for task [17589221062419291787](https://jules.google.com/task/17589221062419291787) started by @notacryptodad*