### PR TITLE
🎨 Palette: Improve accessibility of theme toggle switch and QueryDiffView

### DIFF
--- a/frontend/src/components/QueryDiffView.jsx
+++ b/frontend/src/components/QueryDiffView.jsx
@@ -126,7 +126,7 @@ function QueryDiffView({ iterations, providerId }) {
         {showDiff && (
           <div className="flex items-center space-x-2">
             <span className="text-xs text-gray-500 dark:text-gray-400">View:</span>
-            <select value={viewMode} onChange={(e) => setViewMode(e.target.value)} className="text-xs bg-gray-100 dark:bg-gray-700 border-0 rounded px-2 py-1 text-gray-700 dark:text-gray-300 focus:ring-1 focus:ring-primary-500">
+            <select aria-label="Select diff view mode" value={viewMode} onChange={(e) => setViewMode(e.target.value)} className="text-xs bg-gray-100 dark:bg-gray-700 border-0 rounded px-2 py-1 text-gray-700 dark:text-gray-300 focus:ring-1 focus:ring-primary-500">
               <option value="inline">Inline</option>
               <option value="sideBySide">Side-by-Side</option>
             </select>
@@ -135,7 +135,7 @@ function QueryDiffView({ iterations, providerId }) {
       </div>
       {showDiff && diffPairs.length > 1 && (
         <div className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 rounded px-3 py-2">
-          <button onClick={() => setCurrentPairIndex(Math.max(0, currentPairIndex - 1))} disabled={currentPairIndex === 0} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
+          <button onClick={() => setCurrentPairIndex(Math.max(0, currentPairIndex - 1))} disabled={currentPairIndex === 0} aria-label="Previous iteration" className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
             <ChevronLeft className="w-4 h-4 text-gray-600 dark:text-gray-400" />
           </button>
           <div className="text-xs text-gray-600 dark:text-gray-400">
@@ -143,7 +143,7 @@ function QueryDiffView({ iterations, providerId }) {
             <span className="mx-2">|</span>
             <span>{currentPairIndex + 1} of {diffPairs.length} changes</span>
           </div>
-          <button onClick={() => setCurrentPairIndex(Math.min(diffPairs.length - 1, currentPairIndex + 1))} disabled={currentPairIndex === diffPairs.length - 1} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
+          <button onClick={() => setCurrentPairIndex(Math.min(diffPairs.length - 1, currentPairIndex + 1))} disabled={currentPairIndex === diffPairs.length - 1} aria-label="Next iteration" className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
             <ChevronRight className="w-4 h-4 text-gray-600 dark:text-gray-400" />
           </button>
         </div>

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,8 +17,10 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-      title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
+      title="Toggle dark mode"
     >
       {/* Container for icons with animation */}
       <div className="relative w-5 h-5">


### PR DESCRIPTION
💡 **What**: 
1. Enhanced the `ThemeToggle` component to act as a proper accessibility switch instead of a generic button.
2. Added `aria-label` to the previous and next buttons in `QueryDiffView`.
3. Added `aria-label` to the inline diff dropdown in `QueryDiffView`.

🎯 **Why**: 
1. Screen readers need proper context for state toggles. The `role="switch"` alongside `aria-checked` accurately reflects what the button is doing and its current state.
2. Icon-only buttons (like ChevronLeft/Right) need text descriptors (`aria-label`) so screen readers can announce their purpose ("Previous iteration", "Next iteration").
3. Dropdowns need descriptive labels so users relying on assistive technology understand what they are selecting ("Select diff view mode").

♿ **Accessibility**:
- Added `role="switch"` and `aria-checked` to the ThemeToggle.
- Set `aria-label="Dark mode"` to describe the setting itself, not the action.
- Added descriptive `aria-label`s to unlabelled `<button>`s and `<select>` elements in the `QueryDiffView`.

---
*PR created automatically by Jules for task [9986651194549766454](https://jules.google.com/task/9986651194549766454) started by @notacryptodad*