### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility with switch role

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 What: Refactored the `ThemeToggle` component to act as a proper ARIA switch rather than a standard toggle button with dynamically changing labels.
🎯 Why: Screen reader users frequently interact with settings like dark mode. Without `role="switch"` and `aria-checked`, a toggle button can be confusing, especially if its label changes based on state (e.g. "Switch to dark mode" vs "Switch to light mode").
📸 Before/After: Invisible UX improvement. Visual footprint remains unchanged, maintaining the existing sun/moon transition animation.
♿ Accessibility:
- Swapped action-oriented `aria-label` with a descriptive static noun (`aria-label="Dark mode"`).
- Added `role="switch"` to communicate the binary state control to screen readers.
- Added `aria-checked={darkMode}` to announce state ("Dark mode, switch, checked") reliably.

---
*PR created automatically by Jules for task [8238383727136243145](https://jules.google.com/task/8238383727136243145) started by @notacryptodad*