### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What**: Added standard ARIA roles and attributes to the `ThemeToggle` component to identify it as a switch rather than a generic button.
**🎯 Why**: Screen readers previously heard the toggle as a button that magically changed its label ("Switch to dark mode" -> "Switch to light mode"). The updated version tells screen readers exactly what setting they are modifying ("Dark mode, switch, checked/unchecked"), which is much more predictable and standard.
**📸 Before/After**: Invisible to sighted users, major improvement for screen reader users.
**♿ Accessibility**: Added `role="switch"`, `aria-checked={darkMode}`, and `aria-label="Dark mode"`. Kept `title` prop dynamic for sighted tooltips.

---
*PR created automatically by Jules for task [12096770715543713958](https://jules.google.com/task/12096770715543713958) started by @notacryptodad*