### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 **What:** Added proper ARIA switch pattern to the ThemeToggle component.
🎯 **Why:** To ensure screen readers announce the component correctly. Instead of reading out "Switch to dark mode", it now announces "Dark mode, switch, checked/unchecked", which is the recommended W3C pattern.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Added `role="switch"`, `aria-checked`, and changed `aria-label` to announce the setting rather than the action.

---
*PR created automatically by Jules for task [3122976702840862230](https://jules.google.com/task/3122976702840862230) started by @notacryptodad*