### PR TITLE
🎨 Palette: Enhance ThemeToggle component accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Accessible Theme Toggle Switch
+**Learning:** Using a generic `<button>` with a dynamic `aria-label` that changes text (e.g., "Switch to light mode" / "Switch to dark mode") provides confusing feedback to screen reader users because the name of the control changes underneath them. Standard `role="switch"` is much better.
+**Action:** When implementing toggles for binary states (like Theme), always convert the button to `role="switch"`, set `aria-checked` to reflect the state, and use a static `aria-label` (e.g., "Dark mode") that names the setting itself rather than the action.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -15,9 +15,12 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         transition-colors duration-200
         overflow-hidden
         group
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What:**
Updated the `ThemeToggle` component to use semantic ARIA switch properties and improved its focus state for keyboard navigation.

**🎯 Why:**
Previously, the button used a dynamic `aria-label` ("Switch to light/dark mode"). For screen reader users, changing the name of the control mid-interaction can be disorienting. By treating it as a "Dark mode" switch, it correctly announces the state (on/off) of the setting. Additionally, keyboard users lacked a clear focus indicator, making navigation difficult.

**📸 Before/After:**
*(Visual styling remains unchanged for mouse users. Keyboard users now see a clear primary-colored ring when the toggle receives focus. Screen readers now properly announce "Dark mode, switch, on/off" instead of just "Switch to dark mode, button")*

**♿ Accessibility:**
- Converted generic `<button>` to standard `role="switch"`.
- Bound `aria-checked` to the `darkMode` state variable.
- Provided a static `aria-label="Dark mode"`.
- Added `focus-visible` utility classes for clear keyboard focus indicators.

---
*PR created automatically by Jules for task [15726941180829425661](https://jules.google.com/task/15726941180829425661) started by @notacryptodad*