### PR TITLE
🎨 Palette: Enhance ThemeToggle accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-16 - Theme Toggle Accessibility
+**Learning:** When implementing state switches like a Theme toggle, setting `role="switch"` is not enough. The `aria-label` needs to describe the setting being toggled (e.g. "Dark mode") rather than the action (e.g. "Switch to dark mode"), so screen readers announce it properly as 'Dark mode, switch, checked/unchecked'.
+**Action:** Audit all state toggles and ensure the label describes the state, not the action.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -8,16 +8,19 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
   return (
     <button
       onClick={toggleDarkMode}
+      role="switch"
+      aria-checked={darkMode}
       className={`
         relative p-2 rounded-lg 
         bg-gray-100 dark:bg-gray-700 
         hover:bg-gray-200 dark:hover:bg-gray-600 
+        focus-visible:ring-2
         transition-colors duration-200
         overflow-hidden
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 **What**: Improved the accessibility of the `ThemeToggle` component by adding appropriate ARIA roles, attributes, and keyboard focus styles. Also added a `palette.md` journal entry with key learnings.
🎯 **Why**: To provide clear semantics and state information to screen reader users and to make the toggle keyboard accessible. State toggle elements should have `role="switch"` and their label should describe the state ("Dark mode") rather than the action ("Switch to...").
📸 **Before/After**: Visually, added focus ring on keyboard navigation. Screen readers will now announce "Dark mode, switch, checked" instead of "Switch to dark mode, button".
♿ **Accessibility**: 
- Added `role="switch"`
- Added `aria-checked`
- Changed `aria-label` to "Dark mode"
- Added `focus-visible:ring-2`

---
*PR created automatically by Jules for task [18295226038572220071](https://jules.google.com/task/18295226038572220071) started by @notacryptodad*