### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-17 - Accessible State Toggles
+**Learning:** For components that act as state switches (like the `ThemeToggle`), just providing a static label and click handler is insufficient for screen readers. Screen readers need to know that the button is specifically a switch and what its current state is.
+**Action:** When building a toggle button, always include `role="switch"` and `aria-checked={currentState}`. Additionally, the `aria-label` should simply name the setting itself (e.g., "Dark mode") rather than what the action *does* (e.g., "Switch to dark mode"), so that the screen reader correctly announces "Dark mode, switch, checked/unchecked".

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -8,17 +8,20 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
   return (
     <button
       onClick={toggleDarkMode}
+      role="switch"
+      aria-checked={darkMode}
       className={`
         relative p-2 rounded-lg 
         bg-gray-100 dark:bg-gray-700 
         hover:bg-gray-200 dark:hover:bg-gray-600 
         transition-colors duration-200
         overflow-hidden
+        focus-visible:ring-2
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-      title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      aria-label="Dark mode"
+      title="Dark mode"
     >
       {/* Container for icons with animation */}
       <div className="relative w-5 h-5">


### PR DESCRIPTION
💡 **What:** Improved the accessibility of the Theme Toggle button.
🎯 **Why:** The button previously acted as a generic toggle without informing screen readers of its state or its specific role as a switch. It also lacked a clear visual indicator for keyboard navigation.
📸 **Before/After:** No visible changes on mouse click, but focus outline appears when navigating with keyboard.
♿ **Accessibility:** Added `role="switch"` and `aria-checked` so screen readers correctly announce the toggle state. Renamed `aria-label` to "Dark mode" (instead of "Switch to dark mode") to avoid redundant "Switch to dark mode, switch, checked" announcements. Added `focus-visible:ring-2` to support keyboard navigation.

---
*PR created automatically by Jules for task [14708774247106020990](https://jules.google.com/task/14708774247106020990) started by @notacryptodad*