### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What:** Added `role="switch"`, `aria-checked={darkMode}`, and `aria-label="Dark mode"` to the `ThemeToggle.jsx` component. Removed the dynamic string replacement for the `aria-label`.
**🎯 Why:** The theme toggle functions as a binary setting state, which is best represented as a switch to screen reader users instead of just a generic button.
**📸 Before/After:** Screen readers will now announce "Dark mode, switch, checked" or "unchecked" rather than reading "Switch to dark/light mode, button". The visual UI is unchanged.
**♿ Accessibility:** Enhanced screen reader support with accurate ARIA properties for two-state toggle functionality.

---
*PR created automatically by Jules for task [1314401817200118356](https://jules.google.com/task/1314401817200118356) started by @notacryptodad*