### PR TITLE
🎨 Palette: Improve ThemeToggle Accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 **What:** Upgraded the `ThemeToggle` component to act as a proper switch for screen readers, changing its semantic meaning from a generic button with a changing label to a togglable switch element.

🎯 **Why:** Screen reader users need to know that a toggle button acts as a state switch (on/off) rather than just a standard actionable button. Furthermore, standard a11y best practice for state switches dictates that the aria-label should name the setting itself (e.g. "Dark mode") rather than the action (e.g. "Switch to dark mode") so that it announces properly ("Dark mode, switch, on").

📸 **Before/After:** Not applicable (invisible a11y change).

♿ **Accessibility:**
- Added `role="switch"`
- Added `aria-checked={darkMode}` to announce the current state
- Simplified `aria-label` from dynamic action text to the static setting name "Dark mode"

---
*PR created automatically by Jules for task [3772543325852262441](https://jules.google.com/task/3772543325852262441) started by @notacryptodad*