### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility with switch role

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What:** Added `role="switch"`, `aria-checked={darkMode}`, and changed `aria-label="Dark mode"` to the `ThemeToggle` component.

**🎯 Why:** The theme toggle functions as a binary state switch. Previously, it lacked proper ARIA attributes, causing screen readers to announce it as a generic button without its current state. Additionally, dynamic `aria-label`s (like "Switch to dark mode") are confusing on switch controls; it's better to name the control ("Dark mode") and let the screen reader announce its checked state.

**📸 Before/After:** Screen readers previously announced "Switch to dark mode, button" and didn't read state when toggled. Now they announce "Dark mode, switch, checked/unchecked".

**♿ Accessibility:**
* Added `role="switch"` to properly identify the toggle control.
* Added `aria-checked={darkMode}` to announce its current state.
* Updated `aria-label` to "Dark mode" so it pairs correctly with the checked state.
* Kept the dynamic `title` attribute so mouse users still get a helpful visual tooltip indicating the action.

---
*PR created automatically by Jules for task [6967866999708395197](https://jules.google.com/task/6967866999708395197) started by @notacryptodad*