### PR TITLE
🎨 Palette: Improve Theme Toggle accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What:** Added `role="switch"` and `aria-checked` attributes to the `ThemeToggle` component, and updated the `aria-label` to simply name the setting ("Dark mode") instead of describing the action.

**🎯 Why:** Generic buttons used as toggle switches are inaccessible to screen readers without proper ARIA roles. Previously, the button would just read as "Switch to dark mode, button" or "Switch to light mode, button" without indicating its current state or that it's a toggle switch. This change follows standard UX patterns for state toggle components.

**📸 Before/After:** N/A (Invisible change)

**♿ Accessibility:** Screen readers will now correctly announce this element as "Dark mode, switch, checked" or "Dark mode, switch, unchecked", giving users clear feedback on both the purpose of the control and its current state.

---
*PR created automatically by Jules for task [2841976179941641940](https://jules.google.com/task/2841976179941641940) started by @notacryptodad*