### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility with switch role

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 **What:** Added `role="switch"` and `aria-checked={darkMode}` to the ThemeToggle component, and updated the `aria-label` to be simply "Dark mode".

🎯 **Why:** Previously, the theme toggle was just a button with a dynamic `aria-label` ("Switch to dark mode" / "Switch to light mode"). This is confusing for screen reader users as the accessible name of the element changes entirely. By using the standard `role="switch"` pattern, screen readers will announce it properly as a setting ("Dark mode") with a state ("checked" or "unchecked", or "on" / "off").

📸 **Before/After:** No visual changes.

♿ **Accessibility:**
- Added `role="switch"`
- Added `aria-checked={darkMode}`
- Simplified `aria-label` to "Dark mode" so state is announced via `aria-checked` rather than the label text.

---
*PR created automatically by Jules for task [16217522030806698887](https://jules.google.com/task/16217522030806698887) started by @notacryptodad*