### PR TITLE
🎨 Palette: Improve accessibility of ThemeToggle switch

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - ThemeToggle component switch accessibility
+**Learning:** The ThemeToggle relied heavily on its dynamic aria-label reading either 'Switch to dark mode' or 'Switch to light mode'. A toggle represents a true/false state. For accessibility, it should ideally have the `role="switch"` and present an `aria-checked` attribute, leaving the `aria-label` as the simple name of the control, 'Dark mode'.
+**Action:** Whenever building toggle buttons for preferences, ensure they act semantically as switches, providing state context through `aria-checked` rather than solely changing the action label.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 **What:** Improved the accessibility of the `ThemeToggle` component by adding `role="switch"`, `aria-checked={darkMode}`, and changing the dynamic `aria-label` to a static "Dark mode".

🎯 **Why:** Previously, the toggle button relied entirely on dynamically changing the `aria-label` ("Switch to light mode" / "Switch to dark mode") to convey its state. While technically readable, this forces screen reader users to infer the state from the action label instead of hearing it explicitly. By upgrading the button to a semantic switch (`role="switch"`), screen readers will correctly announce the element's purpose and its current boolean state ("Dark mode, switch, checked/unchecked"), providing a much clearer and standard experience.

📸 **Before/After:** No visual changes.

♿ **Accessibility:**
- Added `role="switch"` to properly identify the control type.
- Added `aria-checked={darkMode}` to programmatically expose the toggle's state.
- Simplified `aria-label` to "Dark mode" to name the control directly.
- Retained the dynamic `title` attribute for visual tooltips.

---
*PR created automatically by Jules for task [9863212579456067652](https://jules.google.com/task/9863212579456067652) started by @notacryptodad*