### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility with switch role

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-26 - ARIA labels for Theme Switch
+**Learning:** The frontend uses 'role=switch' pattern for state switches instead of simple button states.
+**Action:** Use 'role=switch' and 'aria-checked' with the label naming the setting (e.g. 'Dark mode') rather than the action for future state switch components.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,8 +17,10 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-      title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      aria-label="Dark mode"
+      title="Dark mode"
+      role="switch"
+      aria-checked={darkMode}
     >
       {/* Container for icons with animation */}
       <div className="relative w-5 h-5">


### PR DESCRIPTION
💡 **What**: Updated the `ThemeToggle` component to use `role="switch"` and `aria-checked` attributes. Also simplified the `aria-label` and `title` to a static "Dark mode" string.

🎯 **Why**: Previously, the `ThemeToggle` dynamically changed its `aria-label` and `title` from "Switch to dark mode" to "Switch to light mode" depending on the state. For screen reader users, dynamically changing the name of the control is confusing. Standard accessibility practices recommend that the control name remains static (e.g. "Dark mode") while a role such as `switch` or `checkbox` manages the state description via `aria-checked`.

📸 **Before/After**: Visually, the UI does not change. Semantically, the HTML has improved.

♿ **Accessibility**: 
- Added `role="switch"` to properly semantically define the button as a toggle switch.
- Added `aria-checked={darkMode}` to announce the correct state to screen readers.
- Fixed `aria-label` and `title` to statically declare the setting's name, preventing confusion caused by dynamic naming changes.

---
*PR created automatically by Jules for task [921690053329698597](https://jules.google.com/task/921690053329698597) started by @notacryptodad*