### PR TITLE
🎨 Palette: Add ARIA labels to icon-only navigation buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-29 - Missing ARIA Labels on Pagination Buttons
+**Learning:** Found multiple instances where icon-only pagination/navigation buttons (like those using ChevronLeft/ChevronRight) lack ARIA labels, making them inaccessible to screen readers.
+**Action:** Add descriptive aria-labels (e.g., 'Previous change', 'Next change') to all icon-only pagination and navigation buttons.

--- a/frontend/src/components/AdminSidebar.jsx
+++ b/frontend/src/components/AdminSidebar.jsx
@@ -40,6 +40,7 @@ function AdminSidebar() {
           onClick={toggleCollapsed}
           className="p-1.5 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-500 dark:text-gray-400"
           title={collapsed ? 'Expand' : 'Collapse'}
+          aria-label={collapsed ? 'Expand' : 'Collapse'}
         >
           {collapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
         </button>

--- a/frontend/src/components/QueryDiffView.jsx
+++ b/frontend/src/components/QueryDiffView.jsx
@@ -135,7 +135,7 @@ function QueryDiffView({ iterations, providerId }) {
       </div>
       {showDiff && diffPairs.length > 1 && (
         <div className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 rounded px-3 py-2">
-          <button onClick={() => setCurrentPairIndex(Math.max(0, currentPairIndex - 1))} disabled={currentPairIndex === 0} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
+          <button onClick={() => setCurrentPairIndex(Math.max(0, currentPairIndex - 1))} disabled={currentPairIndex === 0} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors" aria-label="Previous change">
             <ChevronLeft className="w-4 h-4 text-gray-600 dark:text-gray-400" />
           </button>
           <div className="text-xs text-gray-600 dark:text-gray-400">
@@ -143,7 +143,7 @@ function QueryDiffView({ iterations, providerId }) {
             <span className="mx-2">|</span>
             <span>{currentPairIndex + 1} of {diffPairs.length} changes</span>
           </div>
-          <button onClick={() => setCurrentPairIndex(Math.min(diffPairs.length - 1, currentPairIndex + 1))} disabled={currentPairIndex === diffPairs.length - 1} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
+          <button onClick={() => setCurrentPairIndex(Math.min(diffPairs.length - 1, currentPairIndex + 1))} disabled={currentPairIndex === diffPairs.length - 1} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors" aria-label="Next change">
             <ChevronRight className="w-4 h-4 text-gray-600 dark:text-gray-400" />
           </button>
         </div>

--- a/frontend/src/components/results/ResultsTable.jsx
+++ b/frontend/src/components/results/ResultsTable.jsx
@@ -153,6 +153,7 @@ function ResultsTable({ data, columns }) {
               onClick={() => table.previousPage()}
               disabled={!table.getCanPreviousPage()}
               className="p-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              aria-label="Previous page"
             >
               <ChevronLeft className="w-5 h-5 text-gray-600 dark:text-gray-400" />
             </button>
@@ -164,6 +165,7 @@ function ResultsTable({ data, columns }) {
               onClick={() => table.nextPage()}
               disabled={!table.getCanNextPage()}
               className="p-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              aria-label="Next page"
             >
               <ChevronRight className="w-5 h-5 text-gray-600 dark:text-gray-400" />
             </button>


### PR DESCRIPTION
💡 **What**: Added `aria-label` attributes to icon-only navigation and pagination buttons across the application (`AdminSidebar`, `QueryDiffView`, and `ResultsTable`). Also logged learning in `.Jules/palette.md`.
🎯 **Why**: Without descriptive ARIA labels, screen readers will only announce these buttons as "button", making it impossible for visually impaired users to understand their function. This ensures equal access to core navigation and pagination features.
📸 **Before/After**: Visually identical. Under the hood, `<button><ChevronLeft/></button>` becomes `<button aria-label="Previous page"><ChevronLeft/></button>`.
♿ **Accessibility**: Resolves WCAG 4.1.2 (Name, Role, Value) violations for icon-only interactive elements.

---
*PR created automatically by Jules for task [1600660562351852445](https://jules.google.com/task/1600660562351852445) started by @notacryptodad*