### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,8 +17,10 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-      title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
+      title="Toggle dark mode"
     >
       {/* Container for icons with animation */}
       <div className="relative w-5 h-5">


### PR DESCRIPTION
**💡 What:** Added `role="switch"` and `aria-checked` to the `ThemeToggle` component. Updated the dynamic `aria-label` to a static "Dark mode".

**🎯 Why:** To follow the ARIA switch pattern for binary state toggles. Previously, the button only exposed an actionable label ("Switch to dark mode") without exposing its current state explicitly via ARIA, making it harder for screen reader users to understand its current state.

**📸 Before/After:** Invisible accessibility change. No visual impact.

**♿ Accessibility:** Improves screen reader experience by properly identifying the element as a switch and clearly exposing its "checked" (dark mode) state, allowing assistive tech to announce "Dark mode, switch, checked" instead of just the action.

---
*PR created automatically by Jules for task [2429294278916203226](https://jules.google.com/task/2429294278916203226) started by @notacryptodad*