### PR TITLE
🎨 Palette: Improve ThemeToggle screen reader accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-31 - [ThemeToggle Accessibility]
+**Learning:** For state switch components like the ThemeToggle, using `aria-label="Dark mode"` with `role="switch"` and `aria-checked` provides better screen reader feedback (e.g., "Dark mode, switch, checked/unchecked") than dynamically swapping the action text ("Switch to dark/light mode").
+**Action:** Consistently use `role="switch"` and static, descriptive setting names for toggle buttons instead of dynamic action labels.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What:** Added `role="switch"`, `aria-checked`, and a static `aria-label="Dark mode"` to the `ThemeToggle` component.

**🎯 Why:** Screen readers perform better with the switch pattern. Instead of a button that announces "Switch to dark mode", a switch correctly announces "Dark mode, switch, checked/unchecked", letting the user know both the setting name and its current state.

**📸 Before/After:** No visual changes.

**♿ Accessibility:**
- Added `role="switch"` for correct semantic meaning.
- Added `aria-checked={darkMode}` to announce the current state.
- Simplified `aria-label` to name the setting itself instead of the action.

---
*PR created automatically by Jules for task [1069696329618135782](https://jules.google.com/task/1069696329618135782) started by @notacryptodad*