### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility with switch role

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 **What:** Added `role="switch"`, `aria-checked`, and a proper static `aria-label="Dark mode"` to the `ThemeToggle` component. The `title` attribute is retained for visual tooltips.
🎯 **Why:** Previously, the theme toggle relied on dynamically swapping the `aria-label` text (e.g., "Switch to dark mode" -> "Switch to light mode"). This is non-standard for toggle buttons and less helpful for screen reader users compared to a standard semantic switch pattern, which announces the state (checked/unchecked) of the toggle setting explicitly.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now properly identify the toggle button as a switch and announce whether "Dark mode" is currently active or inactive based on the `aria-checked` state.

---
*PR created automatically by Jules for task [16401029437173846524](https://jules.google.com/task/16401029437173846524) started by @notacryptodad*