### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility for screen readers

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What**: Added `role="switch"` and `aria-checked` to the `ThemeToggle` component, and updated `aria-label` to "Dark mode".
**🎯 Why**: Screen readers were previously announcing the button generic "Switch to dark mode button", which doesn't accurately communicate its stateful nature. This enhancement ensures screen reader users can accurately identify it as a state toggle and understand whether the setting is on or off.
**♿ Accessibility**: This improves screen reader context, aligning the element with standard UI patterns for switch toggles.

---
*PR created automatically by Jules for task [14366337733856180327](https://jules.google.com/task/14366337733856180327) started by @notacryptodad*