### PR TITLE
🎨 Palette: Improve screen reader accessibility for Theme Toggle

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What:** Added the `switch` ARIA role and `aria-checked` attribute to the Theme Toggle component, and simplified the `aria-label` to just "Dark mode".

**🎯 Why:** Previously, the theme toggle was just announced as a button with an action ("Switch to dark mode"), which is confusing because it doesn't clearly reflect its current state. By using the `role="switch"` pattern, screen readers will correctly announce the control as a toggle switch and explicitly read out its state ("Dark mode, switch, on/off").

**📸 Before/After:** No visual changes. Invisible accessibility improvement.

**♿ Accessibility:** Improves semantic meaning for screen reader users by properly implementing the W3C switch design pattern.

---
*PR created automatically by Jules for task [13256465807313861592](https://jules.google.com/task/13256465807313861592) started by @notacryptodad*