### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility with switch role

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-06 - Accessible Theme Toggle
+**Learning:** State switch components (like a theme toggle using `role="switch"`) need their `aria-label` to name the setting itself (e.g., "Dark mode") rather than the action (e.g., "Switch to dark mode") so screen readers announce the state correctly (e.g., "Dark mode, switch, checked/unchecked").
+**Action:** When converting buttons to switches, ensure the aria-label is a noun phrase representing the setting, not an action phrase.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What:** Added `role="switch"`, `aria-checked`, and a proper `aria-label` noun phrase ("Dark mode") to the `ThemeToggle.jsx` component.
**🎯 Why:** Generic buttons used as toggles are confusing for screen reader users because they do not announce their current state. Setting `role="switch"` correctly communicates the binary toggle behavior. The `aria-label` was updated to be a noun phrase representing the setting, ensuring that screen readers announce the element cleanly as "Dark mode, switch, checked/unchecked", instead of an action phrase like "Switch to dark mode".
**📸 Before/After:** Invisible markup change, no visual updates.
**♿ Accessibility:** Converts a generic icon button to a semantic state switch (`role="switch"`) ensuring screen reader users clearly hear both its purpose and its current activation state.

---
*PR created automatically by Jules for task [6540455018938646427](https://jules.google.com/task/6540455018938646427) started by @notacryptodad*