### PR TITLE
🎨 Palette: Fix accessibility for ThemeToggle by using switch semantics

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-07 - Theme Toggle Accessibility Update
+**Learning:** For state switch components like a theme toggle, applying `role="switch"` and `aria-checked` communicates the exact on/off state to screen readers correctly. Additionally, it is a best practice to set the `aria-label` to the name of the setting itself (e.g., "Dark mode") rather than describing the action (e.g., "Switch to dark mode") so it reads properly ("Dark mode, switch, checked/unchecked").
+**Action:** Always check toggle buttons functioning as state switches for proper role and aria attributes, prioritizing the setting name over the action for the label.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What:** Added `role="switch"` and `aria-checked` to the theme toggle component. Also simplified the `aria-label` to "Dark mode".
**🎯 Why:** Toggle buttons functioning as state switches need correct role and checked state attributes. Labeling it with the setting name ensures the screen reader announces the state correctly (e.g. "Dark mode, switch, checked").
**📸 Before/After:** Invisible fix; visual rendering unchanged.
**♿ Accessibility:** Enhances screen reader interactions. Added correct structural switch semantics instead of dynamically mutating `aria-label`.

---
*PR created automatically by Jules for task [10586566482391472389](https://jules.google.com/task/10586566482391472389) started by @notacryptodad*