### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility with switch role

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-08 - Theme Toggle Role and State Accessibility
+**Learning:** Toggle buttons that function as state switches must include `role="switch"` and `aria-checked` attributes to provide accurate semantic feedback for screen readers. The `aria-label` should name the setting itself (e.g., "Dark mode") rather than the action (e.g., "Switch to dark mode") so screen readers announce the state correctly (e.g., "Dark mode, switch, checked/unchecked").
+**Action:** Always verify that state toggle buttons implement the `switch` role with synchronized `aria-checked` state and noun-based `aria-label`s instead of action-based descriptions.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What:** Added proper ARIA state switch attributes to the `ThemeToggle` component.

**🎯 Why:** Action-based `aria-label` attributes on a toggle without a proper switch role do not clearly communicate state to screen readers. Users would hear "Switch to dark mode, button" instead of the expected "Dark mode, switch, unchecked".

**📸 Before/After:** Screen readers previously announced an action verb and generic "button". They now accurately announce the state of a "switch".

**♿ Accessibility:**
- Added `role="switch"`
- Added `aria-checked` boolean state
- Replaced action-based `aria-label` with a noun-based setting name (`"Dark mode"`).

---
*PR created automatically by Jules for task [3116426461961895124](https://jules.google.com/task/3116426461961895124) started by @notacryptodad*