### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-10 - ThemeToggle Switch Accessibility
+**Learning:** For state switch components like theme toggles, adding `role="switch"` and `aria-checked` provides the correct semantic feedback. Crucially, the `aria-label` should describe the setting itself (e.g., "Dark mode") rather than the action (e.g., "Switch to dark mode") so that screen readers announce the state correctly as "Dark mode, switch, checked/unchecked".
+**Action:** Always verify that interactive switch elements are labeled with their setting name, not the action they perform, and use `role="switch"`.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 What: Replaced dynamic `aria-label` with a static label ("Dark mode") and added `role="switch"` alongside `aria-checked` to the ThemeToggle `<button>`.
🎯 Why: Screen readers would previously announce the action ("Switch to dark mode") without a clear semantic role. A switch correctly conveys the state (on/off) of the setting.
📸 Before/After: No visual changes; all updates are to ARIA attributes.
♿ Accessibility: The button is now properly interpreted by screen readers as a stateful switch, improving the experience for visually impaired users.

---
*PR created automatically by Jules for task [8799644350789889165](https://jules.google.com/task/8799644350789889165) started by @notacryptodad*