### PR TITLE
🎨 Palette: Improve theme toggle accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Theme Toggle switch semantics
+**Learning:** For state switch components like theme toggles, adding `role="switch"` and `aria-checked` provides the exact state cleanly. Most importantly, the `aria-label` must name the setting itself (e.g., "Dark mode") rather than the action (e.g., "Switch to dark mode") so screen readers announce "Dark mode, switch, checked/unchecked" instead of redundant action descriptions.
+**Action:** Always name the object/setting itself on `role="switch"` controls instead of action verbs.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -8,6 +8,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
   return (
     <button
       onClick={toggleDarkMode}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       className={`
         relative p-2 rounded-lg 
         bg-gray-100 dark:bg-gray-700 
@@ -17,7 +20,6 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What:** 
Improved the accessibility of the `ThemeToggle` component by changing it from a simple button with a dynamic label to a semantic switch.

**🎯 Why:** 
Previously, the `aria-label` changed between "Switch to light mode" and "Switch to dark mode". While okay, a proper WAI-ARIA `switch` provides much clearer feedback to screen reader users by consistently announcing the control's name ("Dark mode") and its state ("checked" or "unchecked").

**📸 Before/After:** 
Visuals are identical. Screen reader experience goes from "Switch to dark mode, button" to "Dark mode, switch, unchecked".

**♿ Accessibility:** 
- Added `role="switch"`
- Added `aria-checked` state
- Cleaned up `aria-label` to be noun-based rather than action-based

---
*PR created automatically by Jules for task [3041124709354315159](https://jules.google.com/task/3041124709354315159) started by @notacryptodad*