### PR TITLE
🎨 Palette: Improve accessibility of ThemeToggle component

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,8 +17,10 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-      title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
+      title="Toggle dark mode"
     >
       {/* Container for icons with animation */}
       <div className="relative w-5 h-5">


### PR DESCRIPTION
💡 What: Added `role="switch"` and `aria-checked` attributes to the `ThemeToggle` component and simplified the `aria-label` to just "Dark mode".
🎯 Why: Previously, the screen reader would announce the button using an action phrase ("Switch to light mode" / "Switch to dark mode") which changed dynamically. Following standard a11y practices for a toggle switch, the screen reader will now announce the state more accurately as "Dark mode, switch, checked/unchecked", improving keyboard and screen reader navigation.
📸 Before/After: No visual changes, invisible accessibility enhancement.
♿ Accessibility: Better screen reader announcement for the state switch.

---
*PR created automatically by Jules for task [6839811138765076332](https://jules.google.com/task/6839811138765076332) started by @notacryptodad*