### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility with switch role

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 What: Updated the `ThemeToggle` component to use `role="switch"`, `aria-checked`, and a static `aria-label="Dark mode"`.
🎯 Why: Previously, the button functioned as a generic toggle with a dynamic label ("Switch to light mode" / "Switch to dark mode"), which is less clear for screen reader users than the standard switch pattern.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Screen readers will now announce the component correctly as "Dark mode, switch, checked" or "Dark mode, switch, unchecked", following WCAG best practices for state toggles.

---
*PR created automatically by Jules for task [2565318789469919996](https://jules.google.com/task/2565318789469919996) started by @notacryptodad*