### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility with switch role and correct ARIA states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-18 - [ThemeToggle Accessibility]
+**Learning:** Toggle switches for theme or options in React/Tailwind applications should include `role="switch"` and `aria-checked` properties. Setting `aria-label` to the state itself (e.g., "Dark mode") provides clearer semantics for screen readers than the action string (e.g., "Switch to dark mode") since screen readers will announce "Dark mode, switch, checked/unchecked".
+**Action:** Always implement boolean toggles using `role="switch"` and `aria-checked`. Set the label to the name of the toggle setting instead of an action verb.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
### 💡 What
Updated the `ThemeToggle` component to use the `switch` role and proper ARIA states for accessibility.
- Added `role="switch"`
- Added `aria-checked={darkMode}`
- Replaced dynamic action-oriented `aria-label` with a static descriptive `aria-label="Dark mode"`
- Kept the dynamic `title` attribute for mouse hover tooltips

### 🎯 Why
Toggle components that flip between two boolean states (like Dark/Light mode) should semantically represent a switch rather than a generic button that changes its label completely. Screen readers announce the label + role + state. By setting it to "Dark mode", a screen reader accurately announces "Dark mode, switch, checked/not checked" depending on the user's current settings.

### ♿ Accessibility
- Provides explicit state communication (`aria-checked`) to assistive technologies.
- Eliminates ambiguous dynamic labeling in favor of a static configuration name.

---
*PR created automatically by Jules for task [354404161656688429](https://jules.google.com/task/354404161656688429) started by @notacryptodad*