### PR TITLE
🎨 Palette: Improve ThemeToggle screen reader accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Semantic State Switch for Theme Toggle
+**Learning:** When using toggle buttons for state switches (like theme mode), simply changing `aria-label` dynamically (e.g., "Switch to light mode") makes screen readers announce it as an action button. It is much better UX for screen reader users to use `role="switch"`, dynamically set `aria-checked`, and use a static `aria-label` (e.g., "Dark mode"). This allows screen readers to natively announce "Dark mode, switch, checked/unchecked".
+**Action:** Always use `role="switch"` alongside `aria-checked` and a static descriptive `aria-label` when implementing components that toggle binary states (like settings or themes) instead of action-oriented labels.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 **What**: Refactored the `ThemeToggle` component to use semantic state switch ARIA attributes.
🎯 **Why**: When a setting toggles a binary state (like dark mode), standard buttons don't announce their current state effectively to screen readers.
📸 **Before/After**: N/A - Visual UI remains exactly the same.
♿ **Accessibility**: 
- Added `role="switch"` so screen readers identify it correctly.
- Added `aria-checked={darkMode}` to announce state.
- Changed `aria-label` from dynamic action text ("Switch to...") to static descriptive text ("Dark mode") to support native state announcements.

---
*PR created automatically by Jules for task [14006966103323087023](https://jules.google.com/task/14006966103323087023) started by @notacryptodad*