### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What:**
Added `role="switch"` and `aria-checked` to the `ThemeToggle` component, and updated the `aria-label` to be a noun ("Dark mode") instead of an action ("Switch to dark mode"). 

**🎯 Why:**
Toggle buttons functioning as state switches need a semantic role to correctly inform screen readers of their state. Additionally, `aria-label` on switches should describe the setting being switched rather than the action itself. The action-oriented tooltip text remains in the `title` attribute for sighted users.

**📸 Before/After:**
*(Invisible accessibility change)*

**♿ Accessibility:**
- Added `role="switch"` and `aria-checked={darkMode}`.
- Changed `aria-label` to `"Dark mode"` so that it reads naturally (e.g. "Dark mode, switch, checked/unchecked").

---
*PR created automatically by Jules for task [11387924944075290233](https://jules.google.com/task/11387924944075290233) started by @notacryptodad*