### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-19 - Theme Toggle Switch Pattern
+**Learning:** For a state-switch UI element like a theme toggle button, the `aria-label` should noun-ify the setting (e.g., "Dark mode") instead of providing an action string (e.g., "Switch to dark mode"). Action strings combined with the `switch` role make screen readers announce confusing combinations like "Switch to dark mode, switch, off".
+**Action:** When converting toggle buttons to `role="switch"`, ensure the label names the setting itself rather than describing the action.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
🎨 Palette: Improve accessibility of ThemeToggle

💡 What: Updated the `ThemeToggle` component to use the `switch` role and proper ARIA states.
🎯 Why: The previous button announced an action label ("Switch to dark mode") without exposing its toggled state, which is confusing for screen reader users trying to understand the current active theme.
📸 Before/After: The visual UI remains unchanged.
♿ Accessibility: Added `role="switch"`, bound `aria-checked` to the `darkMode` state, and updated the `aria-label` to simply "Dark mode" so it announces correctly as "Dark mode, switch, on/off".

---
*PR created automatically by Jules for task [15823805239399182713](https://jules.google.com/task/15823805239399182713) started by @notacryptodad*