### PR TITLE
🎨 Palette: Improve ThemeToggle screen reader accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -8,6 +8,8 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
   return (
     <button
       onClick={toggleDarkMode}
+      role="switch"
+      aria-checked={darkMode}
       className={`
         relative p-2 rounded-lg 
         bg-gray-100 dark:bg-gray-700 
@@ -17,7 +19,7 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**What:** Added `role="switch"` and `aria-checked` to the ThemeToggle component, and updated its `aria-label` to "Dark mode".
**Why:** The previous configuration used dynamic `aria-label`s like "Switch to dark mode", which causes confusion for screen reader users as it announces the action rather than the state. By changing it to a formal switch pattern, screen readers can now accurately announce the state (e.g., "Dark mode, switch, checked/unchecked").
**Before/After:** The component previously lacked `role="switch"` and `aria-checked`, instead relying purely on text-based state changes in the `aria-label`. It now correctly uses standard WAI-ARIA switch patterns.
**Accessibility:** Significantly improves semantic feedback for screen reader navigation.

---
*PR created automatically by Jules for task [10868591677999925413](https://jules.google.com/task/10868591677999925413) started by @notacryptodad*