### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-23 - Accessibility for Toggle Switches
+**Learning:** Adding standard `role="switch"` and `aria-checked` to the `ThemeToggle` component, and updating its label to name the setting ("Dark mode") instead of the action, significantly improves screen reader clarity.
+**Action:** Always verify that toggle switches describe the setting rather than the action and use the proper semantic role to give exact feedback on the checked state.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 **What:** Added missing `role="switch"` and `aria-checked` to the `ThemeToggle` component, and updated the `aria-label` to "Dark mode".
🎯 **Why:** To provide proper semantic feedback for screen readers, allowing them to announce the state correctly (e.g., "Dark mode, switch, checked/unchecked") rather than dynamically changing the action label.
📸 **Before/After:** No visual change (invisible accessibility improvement).
♿ **Accessibility:** Screen reader users will now correctly perceive this button as a toggle switch that represents the "Dark mode" setting and can interpret its checked status immediately.

---
*PR created automatically by Jules for task [10351963187091868367](https://jules.google.com/task/10351963187091868367) started by @notacryptodad*