### PR TITLE
🎨 Palette: Improve theme toggle accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-23 - Switch Component State Context
+**Learning:** For state switch components (like a theme toggle using `role="switch"`), the `aria-label` should name the setting itself (e.g., "Dark mode") rather than the action (e.g., "Switch to dark mode"). This allows screen readers to naturally announce the state correctly (e.g., "Dark mode, switch, checked/unchecked") instead of a confusing action-based label.
+**Action:** Always verify `aria-label` wording on toggle switches to ensure it describes the noun/setting rather than the verb/action.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 What: Added `role="switch"`, `aria-checked`, and updated `aria-label` to the `ThemeToggle` component.
🎯 Why: Screen readers previously read the button as a generic button with an action label ("Switch to dark mode") and no clear state indication.
📸 Before/After: Visuals remain exactly the same.
♿ Accessibility: The button now correctly identifies itself as a switch and announces its checked state (e.g. "Dark mode, switch, checked/unchecked") rather than just an action label.

---
*PR created automatically by Jules for task [16609200238214743865](https://jules.google.com/task/16609200238214743865) started by @notacryptodad*