### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility with switch role

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 **What**: The UX enhancement added `role="switch"`, `aria-checked={darkMode}`, and updated the `aria-label` to just `"Dark mode"` on the ThemeToggle button.

🎯 **Why**: Previously, the toggle used an ambiguous action-oriented dynamic label ("Switch to dark mode" / "Switch to light mode") as a standard button. This made it difficult for screen reader users to understand the current state or that it functioned as a binary toggle setting. Naming the setting itself with a switch role fixes this.

📸 **Before/After**: No visual changes; purely structural semantic improvements.

♿ **Accessibility**: Replaced standard button semantics with explicit switch semantics. Screen readers will now announce the setting correctly (e.g., "Dark mode, switch, checked").

---
*PR created automatically by Jules for task [8946780775100699937](https://jules.google.com/task/8946780775100699937) started by @notacryptodad*