### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**What:** Added correct switch semantics (`role="switch"`, `aria-checked`, `aria-label`) to the `ThemeToggle` component.
**Why:** The `ThemeToggle` is effectively a switch. Without the `switch` role and `aria-checked` attribute, screen readers wouldn't announce its checked/unchecked state properly. Furthermore, updating the `aria-label` to simply name the setting ("Dark mode") is best practice, as screen readers read the state automatically alongside the role (e.g. "Dark mode, switch, checked/unchecked") which is much more informative than action-oriented descriptions.
**Accessibility:** Improved screen reader support for the theme toggle button.

---
*PR created automatically by Jules for task [613412067475728165](https://jules.google.com/task/613412067475728165) started by @notacryptodad*