### PR TITLE
🎨 Palette: Enhance ThemeToggle accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,8 +17,10 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-      title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
+      title="Dark mode"
     >
       {/* Container for icons with animation */}
       <div className="relative w-5 h-5">


### PR DESCRIPTION
**💡 What:**
Updated the `ThemeToggle` component to act as a proper accessibility switch by adding `role="switch"` and dynamically updating the `aria-checked` attribute. Also simplified `aria-label` and `title` to statically say "Dark mode", relying on the native switch element announcement for the state.

**🎯 Why:**
Previously, the button used a dynamic `aria-label` ("Switch to dark/light mode"), meaning a screen reader would just announce the action. While functional, standard W3C ARIA guidelines for state toggles prefer a static label paired with `role="switch"` and `aria-checked`. This gives assistive tech users clear context of both what the setting is and what its *current* state is (e.g., "Dark mode, switch, checked"). 

**📸 Before/After:**
*(No visual changes - invisible UX improvement)*

**♿ Accessibility:**
- Added `role="switch"`
- Added `aria-checked={darkMode}`
- Standardized `aria-label` to the setting name ("Dark mode") instead of the action.

---
*PR created automatically by Jules for task [11699523743845650660](https://jules.google.com/task/11699523743845650660) started by @notacryptodad*