### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility with switch role

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What**
Added `role="switch"` and `aria-checked` attributes to the `ThemeToggle` component, and simplified the `aria-label` to "Dark mode".

**🎯 Why**
Previously, the button used a dynamic `aria-label` ("Switch to light mode" / "Switch to dark mode") with no semantic indication of its state. This pattern is confusing for screen reader users because the element's name changes on activation, and its current state isn't explicitly announced. A toggle switch should have a consistent name and a changing state.

**📸 Before/After**
*No visual changes. This is an invisible accessibility improvement.*

**♿ Accessibility**
- Added `role="switch"` so screen readers identify the element as a toggle switch.
- Added `aria-checked={darkMode}` to announce the current state.
- Changed `aria-label` to a static "Dark mode" so it reads naturally (e.g., "Dark mode, switch, checked" when active).

---
*PR created automatically by Jules for task [1998185466020803039](https://jules.google.com/task/1998185466020803039) started by @notacryptodad*