### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility with switch role

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,8 +17,10 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-      title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
+      title="Dark mode"
     >
       {/* Container for icons with animation */}
       <div className="relative w-5 h-5">


### PR DESCRIPTION
**What**: Added `role="switch"` and `aria-checked={darkMode}` to the `ThemeToggle` component. The `aria-label` and `title` attributes were also updated from dynamic action verbs ("Switch to...") to the static name of the setting ("Dark mode").
**Why**: Toggle buttons that function as state switches must include `role="switch"` and `aria-checked` for screen readers to accurately convey their purpose and state. Additionally, naming the setting itself (e.g., "Dark mode") ensures screen readers announce the state correctly (e.g., "Dark mode, switch, on/off") rather than reading the action redundantly.
**Before/After**: Visually identical. Under the hood, screen readers now interpret the component properly.
**Accessibility**: Improves semantic HTML structure and screen reader UX by using the `switch` role pattern.

---
*PR created automatically by Jules for task [6612452274182650418](https://jules.google.com/task/6612452274182650418) started by @notacryptodad*