### PR TITLE
🎨 Palette: Improve ThemeToggle screen reader accessibility with switch role

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**What:** Modified the `ThemeToggle` component to use standard switch semantics (`role="switch"`, `aria-checked`) with a static `aria-label="Dark mode"`.
**Why:** Screen readers correctly announce switch elements by declaring their state (e.g., "Dark mode, switch, checked/unchecked"), which is much more intuitive than generic buttons dynamically swapping their label between "Switch to dark mode" and "Switch to light mode".
**Before/After:** The component functions visually identically, but the underlying markup replaces dynamic `aria-label` switching with robust standard state attributes.
**Accessibility:** Improved screen reader compliance and feedback by adding `role="switch"`, removing the dynamic `aria-label`, and providing standard `aria-checked` bindings.

---
*PR created automatically by Jules for task [10421553938466721524](https://jules.google.com/task/10421553938466721524) started by @notacryptodad*