### PR TITLE
🎨 Palette: Add ARIA labels to diff view navigation buttons

### DIFF
--- a/frontend/src/components/QueryDiffView.jsx
+++ b/frontend/src/components/QueryDiffView.jsx
@@ -135,7 +135,13 @@ function QueryDiffView({ iterations, providerId }) {
       </div>
       {showDiff && diffPairs.length > 1 && (
         <div className="flex items-center justify-between bg-gray-50 dark:bg-gray-800 rounded px-3 py-2">
-          <button onClick={() => setCurrentPairIndex(Math.max(0, currentPairIndex - 1))} disabled={currentPairIndex === 0} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
+          <button
+            onClick={() => setCurrentPairIndex(Math.max(0, currentPairIndex - 1))}
+            disabled={currentPairIndex === 0}
+            className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            aria-label="Previous iteration"
+            title="Previous iteration"
+          >
             <ChevronLeft className="w-4 h-4 text-gray-600 dark:text-gray-400" />
           </button>
           <div className="text-xs text-gray-600 dark:text-gray-400">
@@ -143,7 +149,13 @@ function QueryDiffView({ iterations, providerId }) {
             <span className="mx-2">|</span>
             <span>{currentPairIndex + 1} of {diffPairs.length} changes</span>
           </div>
-          <button onClick={() => setCurrentPairIndex(Math.min(diffPairs.length - 1, currentPairIndex + 1))} disabled={currentPairIndex === diffPairs.length - 1} className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors">
+          <button
+            onClick={() => setCurrentPairIndex(Math.min(diffPairs.length - 1, currentPairIndex + 1))}
+            disabled={currentPairIndex === diffPairs.length - 1}
+            className="p-1 hover:bg-gray-200 dark:hover:bg-gray-700 rounded disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+            aria-label="Next iteration"
+            title="Next iteration"
+          >
             <ChevronRight className="w-4 h-4 text-gray-600 dark:text-gray-400" />
           </button>
         </div>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` attributes to the "Previous" and "Next" icon-only navigation buttons in the `QueryDiffView` component.
🎯 Why: Icon-only buttons lacking accessible names are not identifiable by screen readers, creating an accessibility barrier. This small addition makes the component fully usable by assistive technologies and adds native tooltips for mouse users.
📸 Before/After: Visuals remain unchanged.
♿ Accessibility: Improved screen reader announcements for query iteration navigation controls.

---
*PR created automatically by Jules for task [3244737662395730905](https://jules.google.com/task/3244737662395730905) started by @notacryptodad*