### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 What: Replaced the dynamic `aria-label` with a static `"Dark mode"` label, and added `role="switch"` and `aria-checked` attributes to the ThemeToggle component.

🎯 Why: The previous implementation dynamically changed the `aria-label` ("Switch to light mode" / "Switch to dark mode"), which is non-standard for toggle buttons. Naming the setting itself and using `role="switch"` with `aria-checked` allows screen readers to correctly announce the control's purpose and its current state (e.g., "Dark mode, switch, checked/unchecked").

📸 Before/After: N/A - this is an invisible accessibility improvement.

♿ Accessibility: Added `role="switch"`, `aria-checked`, and a proper static `aria-label` to adhere to W3C WAI-ARIA authoring practices for toggle buttons.

---
*PR created automatically by Jules for task [8597559024599012394](https://jules.google.com/task/8597559024599012394) started by @notacryptodad*