### PR TITLE
🎨 Palette: Improve ThemeToggle accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-07-04 - [ThemeToggle Accessibility Fix]
+**Learning:** Using `aria-label` with dynamic text representing an action (e.g., "Switch to dark mode") on a toggle element confuses screen readers. It's better to name the setting itself (e.g., "Dark mode") and use `role="switch"` with `aria-checked` to communicate state changes.
+**Action:** Always use `role="switch"` and `aria-checked` for state toggles, and keep the `aria-label` static to represent the noun/setting name.

--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 What: Added `role="switch"` and `aria-checked` attributes to the `ThemeToggle` component, and changed the `aria-label` to be statically named "Dark mode".
🎯 Why: Using dynamic text like "Switch to dark mode" in an `aria-label` for a toggle button confuses screen reader users, as the control's identity appears to change. By using a static noun label ("Dark mode") along with `role="switch"` and `aria-checked`, screen readers can correctly announce the control's identity and state (e.g., "Dark mode, switch, checked").
♿ Accessibility: Improved screen reader support for the theme toggle switch.

---
*PR created automatically by Jules for task [17466893192089306456](https://jules.google.com/task/17466893192089306456) started by @notacryptodad*