### PR TITLE
🎨 Palette: Enhance ThemeToggle accessibility semantics

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 What: Modified the `ThemeToggle` component to function as a semantic state switch instead of a generic button, and simplified its `aria-label` to state the setting name ("Dark mode").
🎯 Why: To ensure screen readers announce the toggle correctly as a switch (e.g., "Dark mode, switch, checked") rather than as a button with a dynamic action label.
📸 Before/After: Visual appearance remains identical, purely structural/semantic change.
♿ Accessibility: Added `role="switch"` and `aria-checked={darkMode}`, aligning with W3C best practices for toggle buttons.

---
*PR created automatically by Jules for task [17076951631880542540](https://jules.google.com/task/17076951631880542540) started by @notacryptodad*