### PR TITLE
🎨 Palette: Improve ThemeToggle Accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
💡 **What**: Updated the `ThemeToggle.jsx` component to use the ARIA `switch` role, an `aria-checked` attribute tied to the `darkMode` state, and a static `aria-label="Dark mode"`.

🎯 **Why**: When a toggle button behaves as a binary setting switch (like a dark mode toggle), screen readers need semantic information to announce it as a stateful switch (e.g. "Dark mode, switch, checked") rather than a generic button whose label text suddenly changes from "Switch to dark mode" to "Switch to light mode", which can be confusing.

📸 **Before/After**: Visually identical; fully invisible structural change.

♿ **Accessibility**: 
- Added `role="switch"` to properly semantically identify the element.
- Added `aria-checked={darkMode}` to announce state without needing dynamic labels.
- Simplified `aria-label` to just name the setting being toggled.

---
*PR created automatically by Jules for task [6285873765345578946](https://jules.google.com/task/6285873765345578946) started by @notacryptodad*