### PR TITLE
🎨 Palette: Improve ThemeToggle screen reader accessibility

### DIFF
--- a/frontend/src/components/ThemeToggle.jsx
+++ b/frontend/src/components/ThemeToggle.jsx
@@ -17,7 +17,9 @@ function ThemeToggle({ darkMode, toggleDarkMode, className = '' }) {
         group
         ${className}
       `}
-      aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+      role="switch"
+      aria-checked={darkMode}
+      aria-label="Dark mode"
       title={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
     >
       {/* Container for icons with animation */}


### PR DESCRIPTION
**💡 What:** 
Added `role="switch"` and `aria-checked={darkMode}` to the ThemeToggle component, and updated its `aria-label` to dynamically and correctly reflect the semantics ("Dark mode").

**🎯 Why:**
Toggle buttons that switch between visual states (like dark mode and light mode) need more than just standard button roles to be fully accessible. Using `role="switch"` allows screen readers to announce not only the action but its current boolean state properly.

**📸 Before/After:**
N/A (Invisible change to the DOM structure and screen reader announcement)

**♿ Accessibility:**
Improved the screen reader experience by making the ThemeToggle button accurately announce its "switch" role, current "checked/unchecked" state, and using the correct descriptive labeling.

---
*PR created automatically by Jules for task [16549701307566261869](https://jules.google.com/task/16549701307566261869) started by @notacryptodad*